### PR TITLE
Binary keys with truncation

### DIFF
--- a/app/models/active_support/database_cache/entry.rb
+++ b/app/models/active_support/database_cache/entry.rb
@@ -30,9 +30,6 @@ module ActiveSupport::DatabaseCache
       end
 
       private
-        def pick_value(key)
-        end
-
         def upsert_unique_by
           connection.supports_insert_conflict_target? ? :key : nil
         end

--- a/db/migrate/20221117101940_create_active_support_database_cache_entries.rb
+++ b/db/migrate/20221117101940_create_active_support_database_cache_entries.rb
@@ -1,13 +1,8 @@
 class CreateActiveSupportDatabaseCacheEntries < ActiveRecord::Migration[7.0]
   def change
-    collation = case ActiveRecord::Base.connection.adapter_name
-                when "Mysql2"
-                  "utf8mb4_bin"
-                end
-
     create_table :active_support_database_cache_entries do |t|
-      t.string   :key,       null: false, collation: collation
-      t.binary   :value,     null: false
+      t.binary   :key,       null: false,   limit: 1024
+      t.binary   :value,     null: false,   limit: 512.megabytes
       t.datetime :expires_at
       t.timestamps           null: false
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -12,8 +12,8 @@
 
 ActiveRecord::Schema[7.0].define(version: 2022_11_17_101940) do
   create_table "active_support_database_cache_entries", force: :cascade do |t|
-    t.string "key", null: false
-    t.binary "value", null: false
+    t.binary "key", limit: 1024, null: false
+    t.binary "value", limit: 536870912, null: false
     t.datetime "expires_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/models/active_support/database_cache/entry_test.rb
+++ b/test/models/active_support/database_cache/entry_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 module ActiveSupport::DatabaseCache
   class EntryTest < ActiveSupport::TestCase
     test "set and get cache entries" do
-      Entry.set("hello", "there")
-      assert_equal "there", Entry.get("hello")
+      Entry.set("hello".b, "there")
+      assert_equal "there", Entry.get("hello".b)
     end
   end
 end


### PR DESCRIPTION
Store keys as binary blobs, with up to 1024 bytes and add key truncation.

Set max value size to 512MB which matches the max value size in Redis.