### PR TITLE
Add support for delete_matched

### DIFF
--- a/app/models/active_support/database_cache/entry.rb
+++ b/app/models/active_support/database_cache/entry.rb
@@ -21,6 +21,13 @@ module ActiveSupport::DatabaseCache
         where(key: key).delete_all.nonzero?
       end
 
+      def delete_matched(matcher, batch_size:)
+        like_matcher = arel_table[:key].matches(matcher, nil, true)
+        where(like_matcher).select(:id).find_in_batches(batch_size: batch_size) do |entries|
+          delete_by(id: entries.map(&:id))
+        end
+      end
+
       def increment(key, amount)
         transaction do
           amount += lock.get(key).to_i

--- a/test/active_support/database_cache_test.rb
+++ b/test/active_support/database_cache_test.rb
@@ -10,7 +10,6 @@ class ActiveSupport::DatabaseCacheTest < ActiveSupport::TestCase
   include LocalCacheBehavior
   include CacheIncrementDecrementBehavior
   include CacheInstrumentationBehavior
-  # include ConnectionPoolBehavior
   include EncodedKeyCacheBehavior
 
   setup do

--- a/test/behaviors/local_cache_behavior.rb
+++ b/test/behaviors/local_cache_behavior.rb
@@ -164,7 +164,7 @@ module LocalCacheBehavior
       @cache.write(key, SecureRandom.alphanumeric)
       @cache.write(other_key, SecureRandom.alphanumeric)
       @cache.write(third_key, value)
-      @cache.delete_matched("#{prefix}*")
+      @cache.delete_matched("#{prefix}%")
       assert_not @cache.exist?(key)
       assert_not @cache.exist?(other_key)
       assert_equal value, @cache.read(third_key)

--- a/test/delete_matched_test.rb
+++ b/test/delete_matched_test.rb
@@ -1,0 +1,69 @@
+class DeleteMatchedTest < ActiveSupport::TestCase
+  setup do
+    @cache = nil
+    @namespace = "test-#{SecureRandom.hex}"
+
+    @cache = lookup_store(expires_in: 60)
+    # @cache.logger = Logger.new($stdout)  # For test debugging
+
+    # For LocalCacheBehavior tests
+    @peek = lookup_store(expires_in: 60)
+  end
+
+  test "deletes keys matching glob" do
+    prefix = SecureRandom.alphanumeric
+    key = "#{prefix}#{SecureRandom.uuid}"
+    @cache.write(key, "bar")
+
+    other_key = SecureRandom.uuid
+    @cache.write(other_key, SecureRandom.alphanumeric)
+    @cache.delete_matched("#{prefix}%")
+    assert_not @cache.exist?(key)
+    assert @cache.exist?(other_key)
+  end
+
+  test "deletes exact key" do
+    prefix = SecureRandom.alphanumeric
+    key = "#{prefix}#{SecureRandom.uuid}"
+    @cache.write(key, "bar")
+
+    other_key = SecureRandom.uuid
+    @cache.write(other_key, SecureRandom.alphanumeric)
+    @cache.delete_matched(key)
+    assert_not @cache.exist?(key)
+    assert @cache.exist?(other_key)
+  end
+
+  test "deletes when more items than batch size" do
+    prefix = SecureRandom.alphanumeric
+
+    keys = 5.times.map { "#{prefix}#{SecureRandom.uuid}" }
+    keys.each { |key| @cache.write(key, "bar") }
+
+    other_key = SecureRandom.uuid
+    @cache.write(other_key, SecureRandom.alphanumeric)
+
+    @cache.delete_matched("#{prefix}%", batch_size: 2)
+    keys.each { |key| assert_not @cache.exist?(key) }
+
+    assert @cache.exist?(other_key)
+  end
+
+  test "fails when starts with %" do
+    assert_raise ArgumentError do
+      @cache.delete_matched("%foo")
+    end
+  end
+
+  test "fails when starts with _" do
+    assert_raise ArgumentError do
+      @cache.delete_matched("_foo")
+    end
+  end
+
+  test "fails with regexp matchers" do
+    assert_raise ArgumentError do
+      @cache.delete_matched(/OO/i)
+    end
+  end
+end


### PR DESCRIPTION
The matcher string is used in a SQL like statement. Wildcards are allowed but not as the first character in the string.