### PR TITLE
Database Cache Housekeeping

### DIFF
--- a/db/migrate/20221215113323_add_updated_at_index_to_active_support_database_cache_entries.rb
+++ b/db/migrate/20221215113323_add_updated_at_index_to_active_support_database_cache_entries.rb
@@ -1,0 +1,5 @@
+class AddUpdatedAtIndexToActiveSupportDatabaseCacheEntries < ActiveRecord::Migration[7.0]
+  def change
+    add_index :active_support_database_cache_entries, :updated_at
+  end
+end

--- a/lib/active_support/database_cache.rb
+++ b/lib/active_support/database_cache.rb
@@ -1,8 +1,8 @@
 require "active_support/database_cache/version"
 require "active_support/database_cache/engine"
+require "active_support/database_cache/housekeeper"
 
 module ActiveSupport
   module DatabaseCache
-    # Your code goes here...
   end
 end

--- a/lib/active_support/database_cache/housekeeper.rb
+++ b/lib/active_support/database_cache/housekeeper.rb
@@ -1,0 +1,91 @@
+module ActiveSupport
+  module DatabaseCache
+    class Housekeeper
+      DeleteTask = Struct.new(:count)
+      TouchTask = Struct.new(:ids)
+      HaltTask = Class.new
+
+      attr_reader :task_queue, :housekeeping_thread, :delete_by, :delete_age, :touch_batch_size, :delete_batch_size, :writing_role
+
+      def initialize(delete_by: :updated_at, delete_age: 2.weeks, touch_batch_size: 10, delete_batch_size: 10, writing_role: nil)
+        @task_queue = SizedQueue.new(1000)
+        @delete_by = delete_by
+        @delete_age = delete_age
+        @touch_batch_size = touch_batch_size
+        @delete_batch_size = delete_batch_size
+        @writing_role = writing_role
+        @housekeeping_thread = Thread.new { run_loop }
+      end
+
+      def touch_later(entry_ids:)
+        task_queue.push(TouchTask.new(entry_ids), true)
+      rescue ThreadError
+        false
+      end
+
+      def delete_later(count:)
+        task_queue.push(DeleteTask.new(count), true)
+      rescue ThreadError
+        false
+      end
+
+      def stop(timeout: 0)
+        task_queue.push(HaltTask.new)
+        housekeeping_thread.join(timeout)
+      end
+
+      private
+        def run_loop
+          delete_count = 0
+          touch_ids = []
+
+          loop do
+            task = task_queue.pop
+            case task
+            when DeleteTask
+              delete_count += task.count
+            when TouchTask
+              touch_ids.concat(task.ids)
+            when HaltTask
+              break
+            end
+
+            delete_count -= delete_records(delete_count) if delete_count >= delete_batch_size
+            touch_records(touch_ids) if touch_ids.size >= touch_batch_size
+          end
+        end
+
+        def delete_records(delete_count)
+          total_deleted = 0
+          loop do
+            deleted = with_writing_role do
+              Entry.delete_some(delete_batch_size, delete_by: :updated_at, delete_age: 2.weeks)
+            end
+
+            if deleted < delete_batch_size
+              # indicates there were fewer records available for deletion than the batch size,
+              # so let's reset the deletion counter
+              return delete_count
+            else
+              total_deleted += deleted
+              return total_deleted if (delete_count - total_deleted) < delete_batch_size
+            end
+          end
+        end
+
+        def touch_records(touch_ids)
+          while touch_ids.size >= touch_batch_size do
+            with_writing_role { Entry.touch(touch_ids.shift(touch_batch_size)) }
+          end
+        end
+
+        def with_writing_role
+          if writing_role
+            DatabaseCache::ApplicationRecord.connected_to(role: writing_role) { yield }
+          else
+            yield
+          end
+        end
+    end
+  end
+end

--- a/test/active_support/database_cache/housekeeper_test.rb
+++ b/test/active_support/database_cache/housekeeper_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+require "active_support/testing/method_call_assertions"
+
+class ActiveSupport::DatabaseCache::HousekeeperTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    @cache = nil
+    @namespace = "test-#{SecureRandom.hex}"
+
+    @cache = lookup_store(housekeeper: true, housekeeper_options: { delete_by: :updated_at, delete_age: 2.weeks, touch_batch_size: 2, delete_batch_size: 2 })
+  end
+
+  teardown do
+    @cache.housekeeper.stop
+  end
+
+  def test_deletes_old_records
+    @cache.write("foo", 1)
+    @cache.write("bar", 2)
+    assert_equal 1, @cache.read("foo")
+    assert_equal 2, @cache.read("bar")
+    sleep 0.1 # ensure the housekeeper has marked them as read
+
+    send_entries_back_in_time(3.weeks)
+
+    @cache.write("baz", 3)
+    @cache.write("haz", 4)
+
+    sleep 0.1
+    assert_nil @cache.read("foo")
+    assert_nil @cache.read("bar")
+    assert_equal 3, @cache.read("baz")
+    assert_equal 4, @cache.read("haz")
+  end
+
+  def test_touches_records
+    @cache.write("foo", 1)
+    @cache.write("bar", 2)
+    assert_equal 1, @cache.read("foo")
+    assert_equal 2, @cache.read("bar")
+    sleep 0.1 # ensure the housekeeper has marked them as read
+
+    send_entries_back_in_time(1.week)
+
+    assert_equal 1, @cache.read("foo")
+    assert_equal 2, @cache.read("bar")
+    sleep 0.1
+
+    assert_equal 2, ActiveSupport::DatabaseCache::Entry.where("updated_at > ?", Time.now - 1.minute).count
+  end
+
+  private
+    def send_entries_back_in_time(distance)
+      ActiveSupport::DatabaseCache::Entry.all.each do |entry|
+        entry.update_columns(created_at: entry.created_at - distance, updated_at: entry.updated_at - distance)
+      end
+    end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_17_101940) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_15_113323) do
   create_table "active_support_database_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
     t.binary "value", limit: 536870912, null: false
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_17_101940) do
     t.datetime "updated_at", null: false
     t.index ["expires_at"], name: "index_active_support_database_cache_entries_on_expires_at"
     t.index ["key"], name: "index_active_support_database_cache_entries_on_key", unique: true
+    t.index ["updated_at"], name: "index_active_support_database_cache_entries_on_updated_at"
   end
 
 end

--- a/test/models/active_support/database_cache/entry_test.rb
+++ b/test/models/active_support/database_cache/entry_test.rb
@@ -4,7 +4,7 @@ module ActiveSupport::DatabaseCache
   class EntryTest < ActiveSupport::TestCase
     test "set and get cache entries" do
       Entry.set("hello".b, "there")
-      assert_equal "there", Entry.get("hello".b)
+      assert_equal "there", Entry.get("hello".b)[1]
     end
   end
 end


### PR DESCRIPTION
Introduce a Housekeeper to the database cache. It performs its tasks asynchronously in its own thread to avoid blocking the main one.

**Aim**
The hope is that this will create a self managing LRU cache, with the cache size managed by setting a minimum record age.

It's activity should scale with cache usage so we avoid eating resources on inactive processes.

Communication is done via a SizedQueue, which will prevent memory bloat if the housekeeping thread is starved.

Cache management is best effort or losing messages or shutting down before all tasks are completed is ok.

It has two tasks:
1. Touching read records
2. Deleting old records

**Touching read records**

When the cache does a read a task is queued to touch the records that were read. We want this so we can implement a LRU algorithm for deletions.

The Housekeeper batches up those deletions.

**Deleting old records**

When records are written to the cache we queue a task for the Housekeeper to delete some records. Currently this is set to delete one more record than was written to allow the cache size to shrink if necessary.

The cache is configured with a field to use to find old records. It could be created_at for FIFO, updated_at for LRU or expires_at for fine grained control, but the field should be indexed. It also has a minimum age for record deletion.

Things that still need to be worked on:
- Thread management - priority, stopping, working across forks
- Thread error handling/reporting
- Prevent deletion thrashing - the deletion tries to delete the N oldest records so if we had lots of processes doing this at the same time it might cause issues. Also need to see what happens when there are almost no records to delete.
- Configurablity/defaults

Huge thanks to @dhh and @jorgemanrubia - for their input in Pings and Campfire which helped to shape this idea.