### PR TITLE
Touch records asyncronously

### DIFF
--- a/lib/active_support/database_cache.rb
+++ b/lib/active_support/database_cache.rb
@@ -1,5 +1,6 @@
 require "active_support/database_cache/version"
 require "active_support/database_cache/engine"
+require "active_support/database_cache/async_executor"
 
 module ActiveSupport
   module DatabaseCache

--- a/lib/active_support/database_cache/async_executor.rb
+++ b/lib/active_support/database_cache/async_executor.rb
@@ -1,0 +1,37 @@
+module ActiveSupport
+  module DatabaseCache
+    class AsyncExecutor
+      def initialize(touch_batch_size: 100)
+        @touch_batch_size = touch_batch_size
+
+        @executor = Concurrent::SingleThreadExecutor.new(max_queue: 100, fallback_policy: :discard)
+        @toucher = Toucher.new(touch_batch_size)
+      end
+
+      def touch(ids)
+        execute_on_thread do
+          @toucher.add_ids(ids)
+        end
+      end
+
+      private
+        def execute_on_thread(&block)
+          @executor << block
+        end
+
+      class Toucher
+        def initialize(batch_size)
+          @batch_size = batch_size
+          @ids = []
+        end
+
+        def add_ids(ids)
+          @ids.concat(ids)
+          while @ids.size > @batch_size
+            Entry.touch_by_ids(@ids.shift(@batch_size).uniq)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/async_executor_test.rb
+++ b/test/async_executor_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+require "active_support/testing/method_call_assertions"
+
+class ActiveSupport::DatabaseCache::AsyncExecutorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    @cache = nil
+    @namespace = "test-#{SecureRandom.hex}"
+
+    @cache = lookup_store(touch_batch_size: 2)
+  end
+
+  def test_touches_records
+    @cache.write("foo", 1)
+    @cache.write("bar", 2)
+    assert_equal 1, @cache.read("foo")
+    assert_equal 2, @cache.read("bar")
+
+    sleep 0.1 # wait for them to be marked as read
+
+    send_entries_back_in_time(1.week)
+
+    assert_equal 1, @cache.read("foo")
+    assert_equal 2, @cache.read("bar")
+
+    sleep 0.1
+
+    assert_equal 2, ActiveSupport::DatabaseCache::Entry.where("updated_at > ?", Time.now - 1.minute).count
+  end
+
+  private
+    def send_entries_back_in_time(distance)
+      ActiveSupport::DatabaseCache::Entry.all.each do |entry|
+        entry.update_columns(created_at: entry.created_at - distance, updated_at: entry.updated_at - distance)
+      end
+    end
+end

--- a/test/models/active_support/database_cache/entry_test.rb
+++ b/test/models/active_support/database_cache/entry_test.rb
@@ -4,7 +4,7 @@ module ActiveSupport::DatabaseCache
   class EntryTest < ActiveSupport::TestCase
     test "set and get cache entries" do
       Entry.set("hello".b, "there")
-      assert_equal "there", Entry.get("hello".b)
+      assert_equal "there", Entry.get("hello".b)[1]
     end
   end
 end


### PR DESCRIPTION
We need to touch read records for an LRU cache. However we also want to avoid writing to the records every time we to a cache read.

To handle this we add a `AsyncronousExecutor` that can deal with this and future async tasks (such as deleted old/expired records).

Internally it uses a `Concurrent::SingleThreadExecutor`. It batches up the ids and touches them every `touch_batch_size` records.

This is best effort - we don't attempt to flush the records on shutdown so not everything is guaranteed to by marked.