### PR TITLE
Set connects_to in the engine config

### DIFF
--- a/app/models/solid_cache/record.rb
+++ b/app/models/solid_cache/record.rb
@@ -1,6 +1,8 @@
 module SolidCache
   class Record < ActiveRecord::Base
     self.abstract_class = true
+
+    connects_to **SolidCache.connects_to if SolidCache.connects_to
   end
 end
 

--- a/lib/solid_cache.rb
+++ b/lib/solid_cache.rb
@@ -3,5 +3,21 @@ require "solid_cache/engine"
 require "solid_cache/store"
 
 module SolidCache
-  mattr_accessor :executor
+  mattr_accessor :executor, :connects_to
+
+  def self.all_shard_keys
+    all_shards_config&.keys
+  end
+
+  def self.all_shards_config
+    connects_to && connects_to[:shards]
+  end
+
+  def self.shard_config(shard)
+    all_shards_config && all_shards_config[shard]
+  end
+
+  def self.shard_first_role(shard)
+    shard_config(shard)&.first&.first
+  end
 end

--- a/lib/solid_cache/connection_handling.rb
+++ b/lib/solid_cache/connection_handling.rb
@@ -2,40 +2,46 @@ require "solid_cache/hash_ring"
 
 module SolidCache
   module ConnectionHandling
+    attr_reader :shards, :writing_role, :reading_role
+
     def initialize(options = {})
       super(options)
       role = options.delete(:role)
       @writing_role = options.delete(:writing_role) || role
       @reading_role = options.delete(:reading_role) || role
-      @shards = options[:shards]
-      @hash_ring = @shards && @shards.count > 0 ? HashRing.new(@shards) : nil
+      @shards = options.delete(:shards)
     end
 
     def writing_all_shards
       shards.each do |shard|
-        with_role_and_shard(role: @writing_role, shard: shard) { yield }
+        with_role_and_shard(role: writing_role, shard: shard) { yield }
       end
+    end
+
+    def shards
+      @shards || SolidCache.all_shard_keys || [nil]
     end
 
     private
       def writing_across_shards(list:)
-        across_shards(role: @writing_role, list:) { |list| yield list }
+        across_shards(role: writing_role, list:) { |list| yield list }
       end
 
       def reading_across_shards(list:)
-        across_shards(role: @reading_role, list:) { |list| yield list }
+        across_shards(role: reading_role, list:) { |list| yield list }
       end
 
       def writing_shard(normalized_key:)
-        with_role_and_shard(role: @writing_role, shard: shard_for_normalized_key(normalized_key)) { yield }
+        with_role_and_shard(role: writing_role, shard: shard_for_normalized_key(normalized_key)) { yield }
       end
 
       def reading_shard(normalized_key:)
-        with_role_and_shard(role: @reading_role, shard: shard_for_normalized_key(normalized_key)) { yield }
+        with_role_and_shard(role: reading_role, shard: shard_for_normalized_key(normalized_key)) { yield }
       end
 
       def with_role_and_shard(role:, shard:)
         if role || shard
+          role ||= SolidCache.shard_first_role(shard)
           Record.connected_to(role: role, shard: shard) { yield }
         else
           yield
@@ -48,16 +54,20 @@ module SolidCache
         end
       end
 
-      def in_shards(values)
-        values.group_by { |value| shard_for_normalized_key(value.is_a?(Hash) ? value[:key] : value) }
+      def in_shards(list)
+        if shards.count == 1
+          { shards.first => list }
+        else
+          list.group_by { |value| shard_for_normalized_key(value.is_a?(Hash) ? value[:key] : value) }
+        end
       end
 
       def shard_for_normalized_key(normalized_key)
-        @hash_ring&.get_node(normalized_key) || shards.first
+        hash_ring&.get_node(normalized_key) || shards&.first
       end
 
-      def shards
-        @shards || [Entry.default_shard]
+      def hash_ring
+        @hash_ring ||= shards.count > 0 ? HashRing.new(shards) : nil
       end
   end
 end

--- a/lib/solid_cache/engine.rb
+++ b/lib/solid_cache/engine.rb
@@ -4,14 +4,14 @@ require "solid_cache"
 module SolidCache
   class Engine < ::Rails::Engine
     isolate_namespace SolidCache
+
     config.solid_cache = ActiveSupport::OrderedOptions.new
 
-    initializer "solid_cache.executor" do |app|
-      config.solid_cache.executor = app.executor
+    initializer "solid_cache", before: :run_prepare_callbacks do |app|
+      config.solid_cache.executor ||= app.executor
 
-      config.after_initialize do
-        SolidCache.executor = config.solid_cache.executor
-      end
+      SolidCache.executor = config.solid_cache.executor
+      SolidCache.connects_to = config.solid_cache.connects_to
     end
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -14,7 +14,7 @@ module Dummy
     # For compatibility with applications that use this config
     config.action_controller.include_all_helpers = false
 
-    config.cache_store = [:database, writing_role: :writing, reading_role: :reading]
+    config.cache_store = [:solid_cache_store]
 
     # Configuration for the application, engines, and railties goes here.
     #
@@ -23,5 +23,12 @@ module Dummy
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.solid_cache.connects_to = {
+      shards: {
+        default: { writing: :primary, reading: :primary_replica },
+        shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
+      }
+    }
   end
 end

--- a/test/dummy/config/initializers/cache_connections.rb
+++ b/test/dummy/config/initializers/cache_connections.rb
@@ -1,6 +1,0 @@
-ActiveSupport.on_load(:solid_cache) do
-  connects_to shards: {
-    default: { writing: :primary, reading: :primary_replica },
-    shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
-  }
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
 end
 
 def lookup_store(options = {})
-  ActiveSupport::Cache.lookup_store(:solid_cache_store, { namespace: @namespace, writing_role: :writing, reading_role: :reading, shards: [:default, :shard_one] }.merge(options))
+  ActiveSupport::Cache.lookup_store(:solid_cache_store, { namespace: @namespace }.merge(options))
 end
 
 def send_entries_back_in_time(distance)

--- a/test/touching_test.rb
+++ b/test/touching_test.rb
@@ -9,7 +9,7 @@ class SolidCache::TrimmingTest < ActiveSupport::TestCase
   end
 
   def test_touches_read_records_single_shard
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, shards: nil)
+    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, shards: [:default])
     @cache.write("foo", 1)
     @cache.write("bar", 2)
     assert_equal 1, @cache.read("foo")
@@ -28,7 +28,7 @@ class SolidCache::TrimmingTest < ActiveSupport::TestCase
   end
 
   def test_touches_read_records_multiple_shards
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, shards: [:default, :shard_one])
+    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2)
     default_shard_keys, shard_one_keys = 20.times.map { |i| "key#{i}" }.partition { |key| @cache.shard_for_key(key) == :default }
 
     @cache.write(default_shard_keys[0], 1)

--- a/test/trimming_test.rb
+++ b/test/trimming_test.rb
@@ -9,7 +9,7 @@ class SolidCache::TrimmingTest < ActiveSupport::TestCase
   end
 
   def test_trims_old_records
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, shards: nil)
+    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, shards: [:default])
     @cache.write("foo", 1)
     @cache.write("bar", 2)
     assert_equal 1, @cache.read("foo")
@@ -29,7 +29,7 @@ class SolidCache::TrimmingTest < ActiveSupport::TestCase
   end
 
   def test_trims_old_records_multiple_shards
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, shards: [:default, :shard_one])
+    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2)
     default_shard_keys, shard_one_keys = 20.times.map { |i| "key#{i}" }.partition { |key| @cache.shard_for_key(key) == :default }
 
     @cache.write(default_shard_keys[0], 1)


### PR DESCRIPTION
Let the engine set up the connects_to for the solid_cache table.

Then use that config to provide default shards and roles.