### PR TITLE
Skip the query cache for reads

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -12,11 +12,11 @@ module SolidCache
       end
 
       def get(key)
-        where(key: key).pick(:id, :value)
+        where(key: key).skip_query_cache!.pick(:id, :value)
       end
 
       def get_all(keys)
-        where(key: keys).pluck(:key, :id, :value)
+        where(key: keys).skip_query_cache!.pluck(:key, :id, :value)
       end
 
       def delete_by_key(key)


### PR DESCRIPTION
ActiveSupport caches have their own local caching scheme, so there's no need to pollute the query cache.