### PR TITLE
Delete records by expiry date

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -1,6 +1,7 @@
 module SolidCache
   class Entry < Record
     scope :least_recently_used, -> { order(:updated_at) }
+    scope :longest_expired, -> { where.not(expires_at: nil).order(:expires_at) }
 
     class << self
       def set(key, value, expires_at: nil)


### PR DESCRIPTION
The oldest records are deleted, and if the cache is not full only those that have expired.

If the cache is full, unexpired records will also be deleted. If there are not enough records with an expiry date, lru expiry is used to make up the shortfall.