### PR TITLE
Prefill the trim counters

### DIFF
--- a/lib/solid_cache/trimming.rb
+++ b/lib/solid_cache/trimming.rb
@@ -73,7 +73,9 @@ module SolidCache
       end
 
       def trim_counters
-        @trim_counters ||= shards.to_h { |shard| [shard, 0] }
+        # Pre-fill the first counter to prevent herding and to account
+        # for discarded counters from the last shutdown
+        @trim_counters ||= shards.to_h { |shard| [shard, rand(trim_batch_size)] }
       end
 
       def trim_ids(ids)

--- a/test/unit/trimming_test.rb
+++ b/test/unit/trimming_test.rb
@@ -131,11 +131,12 @@ class SolidCache::TrimmingTest < ActiveSupport::TestCase
     cache_full_value = true
     @cache.write("daz", 5)
     @cache.write("haz", 6)
+    @cache.write("maz", 7)
 
     sleep 0.1
 
-    # 2 records have been deleted
-    assert_equal 4, SolidCache::Entry.count
+    # 4 records have been deleted
+    assert_equal 3, SolidCache::Entry.count
     # 1 of them is the expired record
     assert_not SolidCache::Entry.where(key: namespaced_key("foo")).exists?
   end


### PR DESCRIPTION
Prefill the trim counters with a rand value between 0 and the batch_size - 1.

This has two benefits:
- It prevents herding in the deletion queries by spreading out the initial trim queries
- It helps account for any counters that were discarded on shutdown