### PR TITLE
Don't select the id in get methods

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -10,11 +10,11 @@ module SolidCache
       end
 
       def get(key)
-        where(key: key).skip_query_cache!.pick(:id, :value)
+        where(key: key).skip_query_cache!.pick(:value)
       end
 
       def get_all(keys)
-        where(key: keys).skip_query_cache!.pluck(:key, :id, :value)
+        where(key: keys).skip_query_cache!.pluck(:key, :value).to_h
       end
 
       def delete_by_key(key)

--- a/test/models/solid_cache/entry_test.rb
+++ b/test/models/solid_cache/entry_test.rb
@@ -4,7 +4,7 @@ module SolidCache
   class EntryTest < ActiveSupport::TestCase
     test "set and get cache entries" do
       Entry.set("hello".b, "there")
-      assert_equal "there", Entry.get("hello".b)[1]
+      assert_equal "there", Entry.get("hello".b)
     end
 
     test "id range" do


### PR DESCRIPTION
We were selecting the IDs so we could touch the records, but now we are using FIFO there's no need any more.