### PR TITLE
Update counters synchronously

### DIFF
--- a/lib/solid_cache/async_execution.rb
+++ b/lib/solid_cache/async_execution.rb
@@ -11,7 +11,9 @@ module SolidCache
         current_shard = Entry.current_shard
         @executor << ->() do
           wrap_in_rails_executor do
-            block.call(current_shard)
+            with_role_and_shard(role: writing_role, shard: current_shard) do
+              block.call(current_shard)
+            end
           end
         end
       end

--- a/test/unit/async_executor_test.rb
+++ b/test/unit/async_executor_test.rb
@@ -8,7 +8,7 @@ class SolidCache::AsyncExecutorTest < ActiveSupport::TestCase
     @cache = nil
     @namespace = "test-#{SecureRandom.hex}"
 
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, shards: nil)
+    @cache = lookup_store(trim_batch_size: 2, shards: nil)
   end
 
   def test_async_errors_are_reported

--- a/test/unit/stats_test.rb
+++ b/test/unit/stats_test.rb
@@ -9,7 +9,7 @@ class SolidCache::StatsTest < ActiveSupport::TestCase
   end
 
   def test_stats
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, max_age: 2.weeks.to_i, max_entries: 1000, shards: [:default, :shard_one])
+    @cache = lookup_store(trim_batch_size: 2, max_age: 2.weeks.to_i, max_entries: 1000, shards: [:default, :shard_one])
 
     expected = {
       shards: 2,
@@ -23,7 +23,7 @@ class SolidCache::StatsTest < ActiveSupport::TestCase
   end
 
   def test_stats_with_entries
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, max_age: 2.weeks.to_i, max_entries: 1000, shards: [:default])
+    @cache = lookup_store(trim_batch_size: 2, max_age: 2.weeks.to_i, max_entries: 1000, shards: [:default])
 
     expected_empty = { shards: 1, shards_stats: { default: { max_age: 2.weeks.to_i, oldest_age: nil, max_entries: 1000, entries: 0 } } }
 

--- a/test/unit/trimming_test.rb
+++ b/test/unit/trimming_test.rb
@@ -9,7 +9,7 @@ class SolidCache::TrimmingTest < ActiveSupport::TestCase
   end
 
   def test_trims_old_records
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, max_age: 2.weeks, shards: [:default])
+    @cache = lookup_store(trim_batch_size: 2, max_age: 2.weeks, shards: [:default])
     @cache.write("foo", 1)
     @cache.write("bar", 2)
     assert_equal 1, @cache.read("foo")
@@ -28,7 +28,7 @@ class SolidCache::TrimmingTest < ActiveSupport::TestCase
   end
 
   def test_trims_records_when_the_cache_is_full
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2, shards: [:default], max_age: 2.weeks, max_entries: 2)
+    @cache = lookup_store(trim_batch_size: 3, shards: [:default], max_age: 2.weeks, max_entries: 2)
     @cache.write("foo", 1)
     @cache.write("bar", 2)
     assert_equal 1, @cache.read("foo")
@@ -39,12 +39,12 @@ class SolidCache::TrimmingTest < ActiveSupport::TestCase
 
     sleep 0.1
 
-    # Two records have been deleted
-    assert_equal 2, SolidCache::Entry.count
+    # Three records have been deleted
+    assert_equal 1, SolidCache::Entry.count
   end
 
   def test_trims_old_records_multiple_shards
-    @cache = lookup_store(touch_batch_size: 2, trim_batch_size: 2)
+    @cache = lookup_store(trim_batch_size: 2)
     default_shard_keys, shard_one_keys = 20.times.map { |i| "key#{i}" }.partition { |key| @cache.shard_for_key(key) == :default }
 
     @cache.write(default_shard_keys[0], 1)


### PR DESCRIPTION
Move updating the trim counters to the same calling thread. Only the actual trimming will be done asynchronously which should reduce the amount of work done on the async thread significantly.

Now uses an atomic fixnum as we no longer do all the modifications in a single thread.

Uses compare and set to reduce the counter and trigger trimming. If the atomic fixnum is updated and compare and set returns false, it doesn't retry, assuming that the concurrent thread that updated the counter will trigger trimming instead.