### PR TITLE
Include host and port in cache destination

### DIFF
--- a/lib/solid_cache.rb
+++ b/lib/solid_cache.rb
@@ -17,8 +17,12 @@ module SolidCache
     all_shards_config && all_shards_config[shard]
   end
 
-  def self.shard_databases
-    @shard_databases ||= each_shard.map.to_h { [ Record.current_shard, Record.connection_db_config.database ] }
+  def self.shard_destinations
+    @shard_databases ||= each_shard.map.to_h do
+      config = Record.connection_db_config
+      destination = [ config.try(:host), config.try(:port), config.try(:database) ].compact.join("-")
+      [ Record.current_shard, destination ]
+    end
   end
 
   def self.each_shard

--- a/lib/solid_cache/cluster/connection_handling.rb
+++ b/lib/solid_cache/cluster/connection_handling.rb
@@ -16,8 +16,8 @@ module SolidCache
         @shards ||= @shard_options || SolidCache.all_shard_keys || [nil]
       end
 
-      def database_shards
-        @database_shards ||= shards.compact.to_h { |shard| [ SolidCache.shard_databases[shard], shard ] }
+      def destination_shards
+        @destination_shards ||= shards.compact.to_h { |shard| [ SolidCache.shard_destinations[shard], shard ] }
       end
 
       def writing_all_shards
@@ -84,13 +84,13 @@ module SolidCache
         def shard_for_normalized_key(normalized_key)
           return shards.first if shards.count == 1
 
-          database = consistent_hash.node(normalized_key)
-          database_shards[database]
+          destination = consistent_hash.node(normalized_key)
+          destination_shards[destination]
         end
 
         def consistent_hash
           return nil if shards.count == 1
-          @consistent_hash ||= MaglevHash.new(database_shards.keys)
+          @consistent_hash ||= MaglevHash.new(destination_shards.keys)
         end
 
         def async_if_required

--- a/test/unit/solid_cache_test.rb
+++ b/test/unit/solid_cache_test.rb
@@ -33,10 +33,12 @@ class SolidCacheTest < ActiveSupport::TestCase
     shard_names = [:default, :default2, :primary_shard_one, :primary_shard_two, :secondary_shard_one, :secondary_shard_two]
     expected = shard_names.to_h do |shard_name|
       database_name = SolidCache.connects_to.dig(:shards, shard_name, :writing).to_s
-      [ shard_name, configs.configs_for(env_name: Rails.env, name: database_name).database ]
+      config = configs.configs_for(env_name: Rails.env, name: database_name)
+      destination = [ config.try(:host), config.try(:port), config.try(:database) ].compact.join("-")
+      [ shard_name, destination ]
     end
 
-    assert_equal expected, SolidCache.shard_databases
+    assert_equal expected, SolidCache.shard_destinations
   end
 end
 


### PR DESCRIPTION
Database only just works for SQLite, need host and port to distinguish DBs otherwise.