### PR TITLE
Allow cache node names

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,30 @@ Rails.application.configure do
 end
 ```
 
+### Named shard destinations
+
+By default, the node key used for sharding is the name of the database in `database.yml`.
+
+It is possible to add names for the shards in the cluster config. This will allow you to shuffle or remove shards without breaking consistent hashing.
+
+```ruby
+Rails.application.configure do
+  config.solid_cache.connects_to = {
+    shards: {
+      cache_primary_shard1: { writing: :cache_primary_shard1 },
+      cache_primary_shard2: { writing: :cache_primary_shard2 },
+      cache_secondary_shard1: { writing: :cache_secondary_shard1 },
+      cache_secondary_shard2: { writing: :cache_secondary_shard2 },
+    }
+  }
+
+  primary_cluster = { shards: { cache_primary_shard1: :node1, cache_primary_shard2: :node2 } }
+  secondary_cluster = { shards: { cache_primary_shard1: :node3, cache_primary_shard2: :node4 } }
+  config.cache_store = [ :solid_cache_store, clusters: [ primary_cluster, secondary_cluster ] ]
+end
+```
+
+
 ### Enabling encryption
 
 Add this to an initializer:

--- a/lib/solid_cache.rb
+++ b/lib/solid_cache.rb
@@ -17,14 +17,6 @@ module SolidCache
     all_shards_config && all_shards_config[shard]
   end
 
-  def self.shard_destinations
-    @shard_databases ||= each_shard.map.to_h do
-      config = Record.connection_db_config
-      destination = [ config.try(:host), config.try(:port), config.try(:database) ].compact.join("-")
-      [ Record.current_shard, destination ]
-    end
-  end
-
   def self.each_shard
     return to_enum(:each_shard) unless block_given?
 

--- a/test/unit/solid_cache_test.rb
+++ b/test/unit/solid_cache_test.rb
@@ -27,19 +27,6 @@ class SolidCacheTest < ActiveSupport::TestCase
     shards = SolidCache.each_shard.map { SolidCache::Record.current_shard }
     assert_equal [ :default, :default2, :primary_shard_one, :primary_shard_two, :secondary_shard_one, :secondary_shard_two ], shards
   end
-
-  test "shard_databases" do
-    configs = SolidCache::Record.configurations
-    shard_names = [:default, :default2, :primary_shard_one, :primary_shard_two, :secondary_shard_one, :secondary_shard_two]
-    expected = shard_names.to_h do |shard_name|
-      database_name = SolidCache.connects_to.dig(:shards, shard_name, :writing).to_s
-      config = configs.configs_for(env_name: Rails.env, name: database_name)
-      destination = [ config.try(:host), config.try(:port), config.try(:database) ].compact.join("-")
-      [ shard_name, destination ]
-    end
-
-    assert_equal expected, SolidCache.shard_destinations
-  end
 end
 
 class SolidCacheFailsafeTest < ActiveSupport::TestCase


### PR DESCRIPTION
Consistent hashing relies on using a fixed name for a specific node.

Allow the cluster config to pass in the names to use.