### PR TITLE
Setup the cache in an initializer

### DIFF
--- a/lib/solid_cache/engine.rb
+++ b/lib/solid_cache/engine.rb
@@ -13,5 +13,9 @@ module SolidCache
       SolidCache.executor = config.solid_cache.executor
       SolidCache.connects_to = config.solid_cache.connects_to
     end
+
+    config.after_initialize do
+      Rails.cache.setup! if Rails.cache.is_a?(Store)
+    end
   end
 end

--- a/lib/solid_cache/store.rb
+++ b/lib/solid_cache/store.rb
@@ -34,6 +34,10 @@ module SolidCache
       @primary_cluster = clusters.first
     end
 
+    def setup!
+      clusters.each(&:setup!)
+    end
+
     def delete_matched(matcher, options = {})
       instrument :delete_matched, matcher do
         raise ArgumentError, "Only strings are supported: #{matcher.inspect}" unless String === matcher

--- a/test/unit/cluster_test.rb
+++ b/test/unit/cluster_test.rb
@@ -48,6 +48,7 @@ class ClusterTest < ActiveSupport::TestCase
 
     @primary_cache.delete("foo")
     @cache.fetch("foo") { 2 }
+    sleep 0.1
 
     assert_equal 2, @cache.read("foo")
     assert_equal 2, @primary_cache.read("foo")


### PR DESCRIPTION
The cache cannot be setup until ActiveRecord has been initialized. We'll configure it in an after_initialize hook to avoid the hit of building the consistent hash on the first cache lookup.