### PR TITLE
Use pre-built SQL queries

### DIFF
--- a/test/models/solid_cache/entry_test.rb
+++ b/test/models/solid_cache/entry_test.rb
@@ -7,6 +7,11 @@ module SolidCache
       assert_equal "there", Entry.get("hello".b)
     end
 
+    test "set all and get all cache entries" do
+      Entry.set_all([ { key: "hello".b, value: "there" }, { key: "foo".b, value: "bar" } ])
+      assert_equal({ "foo" => "bar", "hello" => "there" } , Entry.get_all(["hello".b, "foo".b, "bar".b]))
+    end
+
     test "id range" do
       assert_equal 0, Entry.id_range
 

--- a/test/unit/connection_handling_test.rb
+++ b/test/unit/connection_handling_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "active_support/testing/method_call_assertions"
+
+class SolidCache::TrimmingTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    @namespace = "test-#{SecureRandom.hex}"
+  end
+
+  def test_active_record_instrumention
+    instrumented_cache = lookup_store
+    uninstrumented_cache = lookup_store(active_record_instrumentation: false)
+
+    calls = 0
+    callback = ->(*args) { calls += 1 }
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      assert_changes -> { calls } do
+        instrumented_cache.read("foo")
+      end
+      assert_changes -> { calls } do
+        instrumented_cache.write("foo", "bar")
+      end
+      assert_no_changes -> { calls } do
+        uninstrumented_cache.read("foo")
+      end
+      assert_no_changes -> { calls } do
+        uninstrumented_cache.write("foo", "bar")
+      end
+    end
+  end
+end


### PR DESCRIPTION
For `Entry.get` and `Entry.get_all`, let's use pre-built SQL queries and run them with `find_by_sql` to avoid the cost of ActiveRecord query parsing.