### PR TITLE
Use a dedicated thread for each connection

### DIFF
--- a/lib/solid_cache/cluster/async_execution.rb
+++ b/lib/solid_cache/cluster/async_execution.rb
@@ -8,14 +8,17 @@ module SolidCache
 
       private
         def async(&block)
-          # Need current shard right now, not when block is called
-          current_shard = Entry.current_shard
           @executor << ->() do
             wrap_in_rails_executor do
-              with_shard(current_shard) do
-                block.call(current_shard)
-              end
+              block.call
             end
+          end
+        end
+
+        def async_on_current_shard(&block)
+          shard = Entry.current_shard
+          async do
+            execute_on_shard(shard) { block.call }
           end
         end
 

--- a/lib/solid_cache/cluster/trimming.rb
+++ b/lib/solid_cache/cluster/trimming.rb
@@ -26,13 +26,11 @@ module SolidCache
         counter.increment(write_count * TRIM_DELETE_MULTIPLIER)
         value = counter.value
         if value > trim_batch_size && counter.compare_and_set(value, value - trim_batch_size)
-          async { trim_batch }
+          async_on_current_shard { trim_batch }
         end
       end
 
-
       private
-
         def trim_batch
           candidates = Entry.order(:id).limit(trim_batch_size * TRIM_SELECT_MULTIPLIER).select(:id, :created_at).to_a
           candidates.select! { |entry| entry.created_at < max_age.seconds.ago } unless cache_full?


### PR DESCRIPTION
Switching the connection out when we need to change shard is expensive. It requires checking a connection out of the pool. That will verify the connection which requires a round trip to the database.

Instead we'll create a dedicated thread for each connection and run the query on it via a `Concurrent::Promise`.

This has two benefits:
1. There's no connection switching required as each of the threads only talks to one shard.
2. Multi reads and writes can now happen in parallel as we trigger them as before getting the results from the promises.

The existing async operations (trimming and writing to non primary clusters) don't use these executors, they have their own one instead that does the connection switching. We don't need to worry so much about that as they are not time critical operations, but there's some scope here to tidy things up as they have a lot in common with the new threaded operations.