### PR TITLE
Skip the query cache entirely

### DIFF
--- a/lib/solid_cache/cluster/trimming.rb
+++ b/lib/solid_cache/cluster/trimming.rb
@@ -30,15 +30,13 @@ module SolidCache
         end
       end
 
-
       private
-
         def trim_batch
-          candidates = Entry.order(:id).limit(trim_batch_size * TRIM_SELECT_MULTIPLIER).select(:id, :created_at).to_a
+          candidates = Entry.first_n(trim_batch_size * TRIM_SELECT_MULTIPLIER).select(:id, :created_at).to_a
           candidates.select! { |entry| entry.created_at < max_age.seconds.ago } unless cache_full?
           candidates = candidates.sample(trim_batch_size)
 
-          Entry.delete(candidates.map(&:id)) if candidates.any?
+          Entry.delete_by_ids(candidates.map(&:id)) if candidates.any?
         end
 
         def trim_counters

--- a/test/models/solid_cache/entry_test.rb
+++ b/test/models/solid_cache/entry_test.rb
@@ -18,7 +18,7 @@ module SolidCache
       Entry.set("hello".b, "there")
       Entry.set("hello2".b, "there")
 
-      assert_equal 2, Entry.id_range
+      assert_equal 2, Entry.uncached { Entry.id_range }
     end
   end
 end

--- a/test/unit/query_cache_test.rb
+++ b/test/unit/query_cache_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class QueryCacheTest < ActiveSupport::TestCase
+  setup do
+    @cache = nil
+    @namespace = "test-#{SecureRandom.hex}"
+
+    @cache = lookup_store(expires_in: 60, cluster: { shards: [:default] })
+    @peek = lookup_store(expires_in: 60, cluster: { shards: [:default] })
+  end
+
+  test "writes don't clear the AR cache" do
+    SolidCache::Entry.cache do
+      @cache.write(1, "foo")
+      assert_equal 1, SolidCache::Entry.count
+      @cache.write(2, "bar")
+      assert_equal 1, SolidCache::Entry.count
+    end
+    SolidCache::Entry.uncached do
+      assert_equal 2, SolidCache::Entry.count
+    end
+  end
+
+  test "write_multi doesn't clear the AR cache" do
+    SolidCache::Entry.cache do
+      @cache.write(1, "foo")
+      assert_equal 1, SolidCache::Entry.count
+      @cache.write_multi({ "1" => "bar", "2" => "baz"})
+      assert_equal 1, SolidCache::Entry.count
+    end
+    SolidCache::Entry.uncached do
+      assert_equal 2, SolidCache::Entry.count
+    end
+  end
+
+  test "deletes don't clear the AR cache" do
+    SolidCache::Entry.cache do
+      @cache.write(1, "foo")
+      assert_equal 1, SolidCache::Entry.count
+      @cache.delete(1)
+      assert_equal 1, SolidCache::Entry.count
+    end
+    SolidCache::Entry.uncached do
+      assert_equal 0, SolidCache::Entry.count
+    end
+  end
+
+  test "delete matches don't clear the AR cache" do
+    SolidCache::Entry.cache do
+      @cache.write("hello1", "foo")
+      @cache.write("hello2", "bar")
+      assert_equal 2, SolidCache::Entry.count
+      @cache.delete_matched("hello%")
+      assert_equal 2, SolidCache::Entry.count
+    end
+    SolidCache::Entry.uncached do
+      assert_equal 0, SolidCache::Entry.count
+    end
+  end
+end


### PR DESCRIPTION
We want to avoid using the ActiveRecord query cache entirely with SolidCache:

- Read queries don't need to be cached as that is handled by the local cache
- Write queries should not clear the query cache, as you would not expect `Rails.cache.write` to do that.

Ideally we'd just be able to do something like:

```ruby
class SolidCache::Record
  self.uses_query_cache = false
end
```

Absent that we need to do a bunch of gymnastics to get the behaviour we want.

1. Selects - This is easy enough, we just wrap the query in an `uncached` block

3. Upserts - Here we need to avoid calling `connection.exec_insert_all` as that will dirty the query cache. Instead we have to construct the SQL manually and execute it with `connection.exec_query`.

4. Deletes - Similarly we need to avoid calling `connection.delete` here. Again we construct the SQL manually and execute it with `connection.exec_delete`.