### PR TITLE
Fix cache trimming when not sharding

### DIFF
--- a/lib/solid_cache/cluster/connection_handling.rb
+++ b/lib/solid_cache/cluster/connection_handling.rb
@@ -85,7 +85,7 @@ module SolidCache
       end
 
       def with_shard(shard, async: false)
-        if shard
+        if shard && shard != Entry.current_shard
           Record.connected_to(shard: shard) do
             configure_for_query(async: async) { yield }
           end

--- a/lib/solid_cache/cluster/trimming.rb
+++ b/lib/solid_cache/cluster/trimming.rb
@@ -42,7 +42,11 @@ module SolidCache
         def trim_counters
           # Pre-fill the first counter to prevent herding and to account
           # for discarded counters from the last shutdown
-          @trim_counters ||= shards.to_h { |shard| [shard, Concurrent::AtomicFixnum.new(rand(trim_batch_size).to_i)] }
+          @trim_counters ||= if shards.any?
+            shards.to_h { |shard| [shard, Concurrent::AtomicFixnum.new(rand(trim_batch_size).to_i)] }
+          else
+            { SolidCache::Record.default_shard => Concurrent::AtomicFixnum.new(rand(trim_batch_size).to_i) }
+          end
         end
 
         def cache_full?


### PR DESCRIPTION
When we are not sharding ensure that the cache trimming can find a trim_counter.