### PR TITLE
Implement SolidCache::Store#clear

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -36,6 +36,10 @@ module SolidCache
         end
       end
 
+      def clear
+        connection.truncate(table_name)
+      end
+
       def increment(key, amount)
         transaction do
           uncached do

--- a/lib/solid_cache/store/api.rb
+++ b/lib/solid_cache/store/api.rb
@@ -46,7 +46,7 @@ module SolidCache
       end
 
       def clear(options = nil)
-        raise NotImplementedError.new("#{self.class.name} does not support clear")
+        entry_clear
       end
 
       private

--- a/lib/solid_cache/store/entries.rb
+++ b/lib/solid_cache/store/entries.rb
@@ -8,6 +8,12 @@ module SolidCache
           end
         end
 
+        def entry_clear
+          writing_all(failsafe: :clear) do
+            Entry.clear
+          end
+        end
+
         def entry_increment(key, amount)
           writing_key(key, failsafe: :increment) do
             Entry.increment(key, amount)


### PR DESCRIPTION
Risky to have this available, but other Rails caches do it, it will at least be quick by truncating the table and it's needed if we want to use the cache in tests.