### PR TITLE
Allow clear with delete or truncate

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ Solid cache supports these options in addition to the universal `ActiveSupport::
 - `trim_batch_size` - the batch size to use when deleting old records (default: `100`)
 - `max_age` - the maximum age of entries in the cache (default: `2.weeks.to_i`)
 - `max_entries` - the maximum number of entries allowed in the cache (default: `2.weeks.to_i`)
-- `cluster` - a Hash of options for the cache database cluster, e.g `{ shards: [:database1, :database2, :database3] }``
+- `cluster` - a Hash of options for the cache database cluster, e.g `{ shards: [:database1, :database2, :database3] }`
 - `clusters` - and Array of Hashes for multiple cache clusters (ignored if `:cluster` is set)
 - `active_record_instrumentation` - whether to instrument the cache's queries (default: `true`)
+- `clear_with` - clear the cache with `:truncate` or `:delete` (default `truncate`, except for when Rails.env.test? then `delete`)
 
 For more information on cache clusters see [Sharding the cache](#sharding-the-cache)
 ### Cache trimming

--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -36,8 +36,12 @@ module SolidCache
         end
       end
 
-      def clear
+      def clear_truncate
         connection.truncate(table_name)
+      end
+
+      def clear_delete
+        in_batches.delete_all
       end
 
       def increment(key, amount)

--- a/test/models/solid_cache/entry_test.rb
+++ b/test/models/solid_cache/entry_test.rb
@@ -20,5 +20,24 @@ module SolidCache
 
       assert_equal 2, Entry.uncached { Entry.id_range }
     end
+
+    test "clear with truncate" do
+      write_entries
+      assert_equal 20, uncached_entry_count
+      Entry.clear_truncate
+      assert_equal 0, uncached_entry_count
+    end
+
+    test "clear with delete" do
+      write_entries
+      assert_equal 20, uncached_entry_count
+      Entry.clear_delete
+      assert_equal 0, uncached_entry_count
+    end
+
+    private
+      def write_entries(count = 20)
+        Entry.write_multi(count.times.map { |i| { key: "key#{i}", value: "value#{i}" } })
+      end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,3 +40,7 @@ def send_entries_back_in_time(distance)
     end
   end
 end
+
+def uncached_entry_count
+  SolidCache.each_shard.sum { SolidCache::Entry.uncached { SolidCache::Entry.count } }
+end

--- a/test/unit/clear_test.rb
+++ b/test/unit/clear_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class DeleteMatchedTest < ActiveSupport::TestCase
+  setup do
+    @namespace = "test-#{SecureRandom.hex}"
+
+    @delete_cache = lookup_store(expires_in: 60, clear_with: :delete)
+  end
+
+  test "clear by truncation" do
+    cache = lookup_store(expires_in: 60, clear_with: :truncate)
+    write_values(cache)
+
+    cache.clear
+
+    assert_equal cache.clear_with, :truncate
+    assert_equal 0, uncached_entry_count
+  end
+
+  test "clear by deletion" do
+    cache = lookup_store(expires_in: 60, clear_with: :delete)
+    write_values(cache)
+
+    cache.clear
+
+    assert_equal cache.clear_with, :delete
+    assert_equal 0, uncached_entry_count
+  end
+
+  private
+    def write_values(cache)
+      20.times.map { |i| cache.write("key#{i}", "value#{i}") }
+    end
+end


### PR DESCRIPTION
Defaults to `truncate`, but can be set with the `clear_with` option.

If `Rails.test.env?` is true though it will default to `delete` as truncation is not always transactional (e.g. in MySQL) so clearing the cache would break transactional tests.