### PR TITLE
Configurable max key bytesize

### DIFF
--- a/lib/solid_cache/store/api.rb
+++ b/lib/solid_cache/store/api.rb
@@ -1,7 +1,7 @@
 module SolidCache
   class Store
     module Api
-      MAX_KEY_BYTESIZE = 1024
+      DEFAULT_MAX_KEY_BYTESIZE = 1024
       SQL_WILDCARD_CHARS = [ '_', '%' ]
 
       attr_reader :max_key_bytesize
@@ -9,7 +9,7 @@ module SolidCache
       def initialize(options = {})
         super(options)
 
-        @max_key_bytesize = MAX_KEY_BYTESIZE
+        @max_key_bytesize = options.fetch(:max_key_bytesize, DEFAULT_MAX_KEY_BYTESIZE)
         @error_handler = options.fetch(:error_handler, DEFAULT_ERROR_HANDLER)
       end
 

--- a/test/unit/solid_cache_test.rb
+++ b/test/unit/solid_cache_test.rb
@@ -31,6 +31,11 @@ class SolidCacheTest < ActiveSupport::TestCase
       assert_equal [ :default, :primary_shard_one, :primary_shard_two, :secondary_shard_one, :secondary_shard_two ], shards
     end
   end
+
+  test "max key bytesize" do
+    cache = lookup_store(max_key_bytesize: 100)
+    assert_equal 100, cache.send(:normalize_key, SecureRandom.hex(200), {}).bytesize
+  end
 end
 
 class SolidCacheFailsafeTest < ActiveSupport::TestCase


### PR DESCRIPTION
We default to 1024 bytes, but some databases might not be able to have indexes on fields that large.