### PR TITLE
Update testing documentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -250,16 +250,25 @@ The Solid Cache migrations try to create an index with 1024 byte entries. If tha
 
 ## Development
 
-Run the tests with `bin/rails test`. These will run against SQLite.
+Run the tests with `bin/rails test`. By default, these will run against SQLite.
 
-You can also run the tests against MySQL and Postgres. First start up the databases:
+You can also run the tests against MySQL and PostgreSQL. First start up the databases:
 
 ```shell
 $ docker compose up -d
 ```
 
-Then run the tests for the target database
+Next, setup the database schema:
+
+```shell
+$ TARGET_DB=mysql bin/rails db:setup
+$ TARGET_DB=postgres bin/rails db:setup
 ```
+
+
+Then run the tests for the target database:
+
+```shell
 $ TARGET_DB=mysql bin/rails test
 $ TARGET_DB=postgres bin/rails test
 ```


### PR DESCRIPTION
👋 

I saw this new gem pop up and thought I'd look under the hood. 

When following the Development steps, the tests wouldn't run without first creating the test databases within MySQL/PostgreSQL, and running the initial migrations. 

I have updated the docs to suggest they run `db:setup` after running docker-compose.

