### PR TITLE
Use pg gem instead of postgresql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem "sqlite3"
 gem "mysql2"
-gem "postgresql"
+gem "pg"
 
 gem "sprockets-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,6 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.4)
     minitest (5.19.0)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
@@ -138,8 +137,6 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.4.5)
-    postgresql (1.0.0)
-      pg
     racc (1.7.1)
     rack (2.2.8)
     rack-test (2.1.0)
@@ -210,8 +207,9 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.5.4)
-      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.6.6-arm64-darwin)
+    sqlite3 (1.6.6-x86_64-darwin)
+    sqlite3 (1.6.6-x86_64-linux)
     thor (1.2.1)
     timeout (0.3.1)
     tzinfo (2.0.6)
@@ -233,7 +231,7 @@ DEPENDENCIES
   debug
   mocha
   mysql2
-  postgresql
+  pg
   rubocop-37signals!
   solid_cache!
   sprockets-rails


### PR DESCRIPTION
“pg” is the proper gem to use. “postgresql” is just to help when they get the name wrong.