### PR TITLE
CI: don't fail fast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: [3.2.2]
         database: [sqlite, postgres, mysql]


### PR DESCRIPTION
It would be wonderful to see, if change in OR fails with all versions of DB or just one. Fail fast setting unfortunately stops when it encounters first failure.