### PR TITLE
Remove unused redefined method SolidCache::Entry.expire(ids)

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -21,10 +21,6 @@ module SolidCache
         select_all_no_query_cache(get_all_sql(serialized_keys), serialized_keys).to_h
       end
 
-      def expire(ids)
-        delete_no_query_cache(:id, ids) if ids.any?
-      end
-
       def delete_by_key(key)
         delete_no_query_cache(:key, to_binary(key))
       end


### PR DESCRIPTION
The method SolidCache::Entry.expire is defined twice on that class.

The one that is actually used by the gem is defined in the lines 67-71:
https://github.com/rails/solid_cache/blob/e4865809025d650736d818fce26d09737f6623b1/app/models/solid_cache/entry.rb#L67-L71