### PR TITLE
Chore: Rename unused parameter

### DIFF
--- a/lib/solid_cache/connections/single.rb
+++ b/lib/solid_cache/connections/single.rb
@@ -17,7 +17,7 @@ module SolidCache
         Record.with_shard(name, &block)
       end
 
-      def with_connection_for(key, &block)
+      def with_connection_for(_key, &block)
         with(name, &block)
       end
 


### PR DESCRIPTION
Ref: https://docs.rubocop.org/rubocop/cops_lint.html#lintunusedmethodargument