### PR TITLE
Use the default SolidCache::Record role

### DIFF
--- a/app/models/solid_cache/record.rb
+++ b/app/models/solid_cache/record.rb
@@ -14,8 +14,8 @@ module SolidCache
       end
 
       def with_shard(shard, &block)
-        if shard && shard != Record.current_shard
-          Record.connected_to(shard: shard, &block)
+        if shard && SolidCache.connects_to
+          connected_to(shard: shard, role: default_role, prevent_writes: false, &block)
         else
           block.call
         end

--- a/lib/solid_cache.rb
+++ b/lib/solid_cache.rb
@@ -22,7 +22,7 @@ module SolidCache
 
     if (shards = all_shards_config&.keys)
       shards.each do |shard|
-        Record.connected_to(shard: shard) { yield }
+        Record.with_shard(shard) { yield }
       end
     else
       yield

--- a/test/unit/solid_cache_test.rb
+++ b/test/unit/solid_cache_test.rb
@@ -33,6 +33,15 @@ class SolidCacheTest < ActiveSupport::TestCase
     end
   end
 
+  test "each_shard uses the default role" do
+    role = ActiveRecord::Base.connected_to(role: :reading) { SolidCache.each_shard.map { SolidCache::Record.current_role } }
+    if ENV["NO_CONNECTS_TO"]
+      assert_equal [ :reading ], role
+    else
+      assert_equal [ :writing, :writing, :writing, :writing, :writing ], role
+    end
+  end
+
   test "max key bytesize" do
     cache = lookup_store(max_key_bytesize: 100)
     assert_equal 100, cache.send(:normalize_key, SecureRandom.hex(200), {}).bytesize


### PR DESCRIPTION
Don't let the ActiveRecord::Base role bleed into the SolidCache connections. This is a problem when the default role is :reading and the SolidCache connection does not have a value set.