### PR TITLE
fix empty binds

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -113,7 +113,7 @@ module SolidCache
             if connection.prepared_statements?
               result = connection.select_all(sanitize_sql(query), "#{name} Load", Array(values), preparable: true)
             else
-              result = connection.select_all(sanitize_sql([ query, values ]), "#{name} Load", nil, preparable: false)
+              result = connection.select_all(sanitize_sql([ query, values ]), "#{name} Load", [], preparable: false)
             end
 
             result.cast_values(SolidCache::Entry.attribute_types)

--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -113,7 +113,7 @@ module SolidCache
             if connection.prepared_statements?
               result = connection.select_all(sanitize_sql(query), "#{name} Load", Array(values), preparable: true)
             else
-              result = connection.select_all(sanitize_sql([ query, values ]), "#{name} Load", [], preparable: false)
+              result = connection.select_all(sanitize_sql([ query, values ]), "#{name} Load", Array(values), preparable: false)
             end
 
             result.cast_values(SolidCache::Entry.attribute_types)


### PR DESCRIPTION
put the right default binds value as in https://github.com/rails/rails/blob/bf725a787609cf24ae64d763636513fc0bfdd4bf/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L100

otherwise, I have that following error 
```
 NoMethodError:
       undefined method `map' for nil:NilClass
     # /usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/quoting.rb:235:in `type_casted_binds'
     # /usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/connection_adapters/postgresql_adapter.rb:891:in `exec_no_cache'
     # /usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/connection_adapters/postgresql_adapter.rb:872:in `execute_and_clear'
     # /usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:64:in `internal_exec_query'
     # /usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/database_statements.rb:630:in `select'
     # /usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/database_statements.rb:71:in `select_all'
     # /usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/query_cache.rb:114:in `select_all'
     # /usr/local/bundle/gems/solid_cache-0.2.0/app/models/solid_cache/entry.rb:116:in `block in select_all_no_query_cache'
     # /usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/query_cache.rb:83:in `uncached'
     # /usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/query_cache.rb:21:in `uncached'
     # /usr/local/bundle/gems/solid_cache-0.2.0/app/models/solid_cache/entry.rb:112:in `select_all_no_query_cache'
     # /usr/local/bundle/gems/solid_cache-0.2.0/app/models/solid_cache/entry.rb:16:in `read'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/store/entries.rb:48:in `block in entry_read'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/store/clusters.rb:26:in `block (2 levels) in reading_key'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/cluster/execution.rb:45:in `instrument'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/cluster/execution.rb:27:in `execute'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/cluster/connections.rb:23:in `block in with_connection_for'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/connections/unmanaged.rb:15:in `with_connection_for'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/cluster/connections.rb:22:in `with_connection_for'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/store/clusters.rb:25:in `block in reading_key'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/store/failsafe.rb:20:in `failsafe'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/store/clusters.rb:24:in `reading_key'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/store/entries.rb:47:in `entry_read'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/store/api.rb:57:in `read_serialized_entry'
     # /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/cache/strategy/local_cache.rb:130:in `read_serialized_entry'
     # /usr/local/bundle/gems/solid_cache-0.2.0/lib/solid_cache/store/api.rb:53:in `read_entry'
     # /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/cache.rb:460:in `block in fetch'
     # /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/cache.rb:1030:in `block in _instrument'
     # /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/notifications.rb:206:in `block in instrument'
     # /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
     # /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/notifications.rb:206:in `instrument'
     # /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/cache.rb:1029:in `_instrument'
     # /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/cache.rb:1006:in `instrument'
     # /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/cache.rb:459:in `fetch'
```