### PR TITLE
Add Rails supported Ruby versions on CI and update appraisals

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [3.2.2]
+        ruby-version: ["3.0", "3.1", "3.2", "3.3"]
         gemfile: [ rails_7, rails_7_1, rails_main ]
         database: [sqlite, postgres, mysql]
+        exclude:
+        - ruby-version: "3.0"
+          gemfile: rails_main # Rails > 7.1 supports Ruby >= 3.1
     services:
       redis:
         image: redis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ To run a test for a specific version run:
 bundle exec appraisal rails-7-1 bin/rails test
 ```
 
-After updating the dependencies in then `Gemfile` please run:
+After updating the dependencies in the `Gemfile` please run:
 
 ```shell
 $ bundle

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 71e29aaa0ffecf13da37428f7cbae110cd104689
+  revision: 45afb81bdeb7c74a3182b961cc2a9ca30dbb47e3
   branch: 7-0-stable
   specs:
     actionpack (7.0.8)
@@ -61,7 +61,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.5)
     builder (3.2.4)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     crass (1.0.6)
     debug (1.9.1)
       irb (~> 1.10)
@@ -74,16 +74,16 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.7.1)
-    irb (1.11.0)
+    irb (1.11.1)
       rdoc
-      reline (>= 0.3.8)
+      reline (>= 0.4.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.0.0)
-    minitest (5.20.0)
+    minitest (5.21.1)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.2.0)
@@ -95,7 +95,7 @@ GEM
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
-    parser (3.2.2.4)
+    parser (3.3.0.4)
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
@@ -116,15 +116,15 @@ GEM
     rake (13.1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
-    regexp_parser (2.8.3)
-    reline (0.4.1)
+    regexp_parser (2.9.0)
+    reline (0.4.2)
       io-console (~> 0.5)
     rexml (3.2.6)
-    rubocop (1.59.0)
+    rubocop (1.60.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -135,12 +135,12 @@ GEM
       parser (>= 3.2.1.0)
     rubocop-md (1.2.2)
       rubocop (>= 1.0)
-    rubocop-minitest (0.34.3)
+    rubocop-minitest (0.34.4)
       rubocop (>= 1.39, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     rubocop-packaging (0.5.2)
       rubocop (>= 1.33, < 2.0)
-    rubocop-performance (1.20.1)
+    rubocop-performance (1.20.2)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     rubocop-rails (2.23.1)
@@ -172,6 +172,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 8040c05b4695e02ed17e6b4892008e66559c2877
+  revision: a0eef52b44ca963177d38198c0501297cb8f61f1
   branch: 7-1-stable
   specs:
     actionpack (7.1.2)
@@ -66,7 +66,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.5)
     builder (3.2.4)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
     debug (1.9.1)
@@ -80,15 +80,15 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.7.1)
-    irb (1.11.0)
+    irb (1.11.1)
       rdoc
-      reline (>= 0.3.8)
+      reline (>= 0.4.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    minitest (5.20.0)
+    minitest (5.21.1)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.2.0)
@@ -100,7 +100,7 @@ GEM
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
-    parser (3.2.2.4)
+    parser (3.3.0.4)
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
@@ -126,15 +126,15 @@ GEM
     rake (13.1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
-    regexp_parser (2.8.3)
-    reline (0.4.1)
+    regexp_parser (2.9.0)
+    reline (0.4.2)
       io-console (~> 0.5)
     rexml (3.2.6)
-    rubocop (1.59.0)
+    rubocop (1.60.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -145,12 +145,12 @@ GEM
       parser (>= 3.2.1.0)
     rubocop-md (1.2.2)
       rubocop (>= 1.0)
-    rubocop-minitest (0.34.3)
+    rubocop-minitest (0.34.4)
       rubocop (>= 1.39, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     rubocop-packaging (0.5.2)
       rubocop (>= 1.33, < 2.0)
-    rubocop-performance (1.20.1)
+    rubocop-performance (1.20.2)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     rubocop-rails (2.23.1)
@@ -184,6 +184,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: f6f6b0542fd9ae6aebe3529baba358d521d64638
+  revision: cb035bde4e4a09789792ba69117f602231c36584
   branch: main
   specs:
     actionpack (7.2.0.alpha)
@@ -66,7 +66,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.5)
     builder (3.2.4)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
     debug (1.9.1)
@@ -80,15 +80,15 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.7.1)
-    irb (1.11.0)
+    irb (1.11.1)
       rdoc
-      reline (>= 0.3.8)
+      reline (>= 0.4.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    minitest (5.20.0)
+    minitest (5.21.1)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
     mysql2 (0.5.5)
@@ -99,7 +99,7 @@ GEM
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
-    parser (3.2.2.4)
+    parser (3.3.0.4)
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
@@ -125,15 +125,15 @@ GEM
     rake (13.1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
-    regexp_parser (2.8.3)
-    reline (0.4.1)
+    regexp_parser (2.9.0)
+    reline (0.4.2)
       io-console (~> 0.5)
     rexml (3.2.6)
-    rubocop (1.59.0)
+    rubocop (1.60.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -144,12 +144,12 @@ GEM
       parser (>= 3.2.1.0)
     rubocop-md (1.2.2)
       rubocop (>= 1.0)
-    rubocop-minitest (0.34.3)
+    rubocop-minitest (0.34.4)
       rubocop (>= 1.39, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     rubocop-packaging (0.5.2)
       rubocop (>= 1.33, < 2.0)
-    rubocop-performance (1.20.1)
+    rubocop-performance (1.20.2)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     rubocop-rails (2.23.1)
@@ -184,6 +184,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
👋 Thanks for the review in advance.

- Adds Rails supported Ruby versions including 3.3 in the CI matrix.
- It also updates the appraisals to update Nokogiri as on Ruby 3.3
the current version on *.lock files was failing as below:
```
nokogiri-1.15.4-x86_64-linux requires ruby version < 3.3.dev, >= 2.7, which is
incompatible with the current version, 3.3.0
```