### PR TITLE
Remove leading new-line in cluster.rb

### DIFF
--- a/lib/solid_cache/cluster.rb
+++ b/lib/solid_cache/cluster.rb
@@ -1,4 +1,3 @@
-
 module SolidCache
   class Cluster
     include Connections, Execution, Expiry, Stats


### PR DESCRIPTION
I know it is cosmetic change, but it is so uncommon in Ruby to start with empty line (at least to me) I couldn't resist to open PR to fix this file.