### PR TITLE
Handle max_age: nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Solid Cache supports these options in addition to the standard `ActiveSupport::C
 - `error_handler` - a Proc to call to handle any `ActiveRecord::ActiveRecordError`s that are raises (default: log errors as warnings)
 - `expiry_batch_size` - the batch size to use when deleting old records (default: `100`)
 - `expiry_method` - what expiry method to use `thread` or `job` (default: `thread`)
-- `max_age` - the maximum age of entries in the cache (default: `2.weeks.to_i`)
+- `max_age` - the maximum age of entries in the cache (default: `2.weeks.to_i`). Can be set to `nil`, but this is not recommended unless using `max_entries` to limit the size of the cache.
 - `max_entries` - the maximum number of entries allowed in the cache (default: `nil`, meaning no limit)
 - `cluster` - a Hash of options for the cache database cluster, e.g `{ shards: [:database1, :database2, :database3] }`
 - `clusters` - and Array of Hashes for multiple cache clusters (ignored if `:cluster` is set)

--- a/test/unit/expiry_test.rb
+++ b/test/unit/expiry_test.rb
@@ -36,7 +36,7 @@ class SolidCache::ExpiryTest < ActiveSupport::TestCase
     end
 
     test "expires records when the cache is full (#{expiry_method})" do
-      @cache = lookup_store(expiry_batch_size: 3, max_age: 2.weeks, max_entries: 2, expiry_method: expiry_method)
+      @cache = lookup_store(expiry_batch_size: 3, max_age: nil, max_entries: 2, expiry_method: expiry_method)
       default_shard_keys = shard_keys(@cache, :default)
       @cache.write(default_shard_keys[0], 1)
       @cache.write(default_shard_keys[1], 2)


### PR DESCRIPTION
Right now, Solid Cache will accept a config with `max_age: nil` but will throw a `NoMethodError` when attempting to expire entries with that config. Such a config should be handled or disallowed.

Since `max_entries: nil` is allowed, this PR allows a nil value for `max_age` as well.