### PR TITLE
Improve performance of delete_multi method

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -34,6 +34,11 @@ module SolidCache
         end
       end
 
+      def delete_multi(keys)
+        serialized_keys = keys.map { |key| to_binary(key) }
+        delete_no_query_cache(:key, serialized_keys)
+      end
+
       def clear_truncate
         connection.truncate(table_name)
       end

--- a/lib/solid_cache/store/api.rb
+++ b/lib/solid_cache/store/api.rb
@@ -119,7 +119,7 @@ module SolidCache
         end
 
         def delete_multi_entries(entries, **options)
-          entries.count { |key| delete_entry(key, **options) }
+          entry_delete_multi(entries).compact.sum
         end
 
         def serialize_entry(entry, raw: false, **options)

--- a/lib/solid_cache/store/entries.rb
+++ b/lib/solid_cache/store/entries.rb
@@ -78,6 +78,12 @@ module SolidCache
             Entry.delete_by_key(key)
           end
         end
+
+        def entry_delete_multi(entries)
+          writing_keys(entries, failsafe: :delete_multi_entries, failsafe_returning: false) do
+            Entry.delete_multi(entries)
+          end
+        end
     end
   end
 end


### PR DESCRIPTION
I noticed that the `delete_multi` method is slow and makes n queries - It would be faster to delete multiple records with a single query.

