### PR TITLE
Remove support for delete_matched

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -27,13 +27,6 @@ module SolidCache
         delete_no_query_cache(:key, to_binary(key))
       end
 
-      def delete_matched(matcher, batch_size:)
-        like_matcher = arel_table[:key].matches(matcher, nil, true)
-        where(like_matcher).select(:id).find_in_batches(batch_size: batch_size) do |entries|
-          delete_no_query_cache(:id, entries.map(&:id))
-        end
-      end
-
       def delete_multi(keys)
         serialized_keys = keys.map { |key| to_binary(key) }
         delete_no_query_cache(:key, serialized_keys)

--- a/lib/solid_cache/store/api.rb
+++ b/lib/solid_cache/store/api.rb
@@ -14,20 +14,6 @@ module SolidCache
         @max_key_bytesize = options.fetch(:max_key_bytesize, DEFAULT_MAX_KEY_BYTESIZE)
       end
 
-      def delete_matched(matcher, options = {})
-        instrument :delete_matched, matcher do
-          raise ArgumentError, "Only strings are supported: #{matcher.inspect}" unless String === matcher
-          raise ArgumentError, "Strings cannot start with wildcards" if SQL_WILDCARD_CHARS.include?(matcher[0])
-
-          options ||= {}
-          batch_size = options.fetch(:batch_size, 1000)
-
-          matcher = namespace_key(matcher, options)
-
-          entry_delete_matched(matcher, batch_size)
-        end
-      end
-
       def increment(name, amount = 1, options = nil)
         options = merged_options(options)
         key = normalize_key(name, options)

--- a/lib/solid_cache/store/entries.rb
+++ b/lib/solid_cache/store/entries.rb
@@ -17,12 +17,6 @@ module SolidCache
       end
 
       private
-        def entry_delete_matched(matcher, batch_size)
-          writing_all(failsafe: :delete_matched) do
-            Entry.delete_matched(matcher, batch_size: batch_size)
-          end
-        end
-
         def entry_clear
           writing_all(failsafe: :clear) do
             if clear_with == :truncate

--- a/test/unit/cluster_test.rb
+++ b/test/unit/cluster_test.rb
@@ -86,19 +86,6 @@ class ClusterTest < ActiveSupport::TestCase
       assert_equal values, @secondary_cache.read_multi("foo", "egg")
     end
 
-    test "delete_matched deletes from both caches" do
-      values = { "foo" => "bar", "baz" => "zab", "bab" => "dab" }
-      @cache.write_multi(values)
-      sleep 0.1
-
-      @cache.delete_matched("ba%")
-      sleep 0.1
-
-      assert_equal({ "foo" => "bar" }, @cache.read_multi(*values.keys))
-      assert_equal({ "foo" => "bar" }, @primary_cache.read_multi(*values.keys))
-      assert_equal({ "foo" => "bar" }, @secondary_cache.read_multi(*values.keys))
-    end
-
     test "increment and decrement hit both clusters" do
       @cache.write("foo", 1, raw: true)
       sleep 0.1

--- a/test/unit/delete_matched_test.rb
+++ b/test/unit/delete_matched_test.rb
@@ -14,60 +14,8 @@ class DeleteMatchedTest < ActiveSupport::TestCase
     @peek = lookup_store(expires_in: 60)
   end
 
-  test "deletes keys matching glob" do
+  test "deletes matched raises a NotImplementedError" do
     prefix = SecureRandom.alphanumeric
-    key = "#{prefix}#{SecureRandom.uuid}"
-    @cache.write(key, "bar")
-
-    other_key = SecureRandom.uuid
-    @cache.write(other_key, SecureRandom.alphanumeric)
-    @cache.delete_matched("#{prefix}%")
-    assert_not @cache.exist?(key)
-    assert @cache.exist?(other_key)
-  end
-
-  test "deletes exact key" do
-    prefix = SecureRandom.alphanumeric
-    key = "#{prefix}#{SecureRandom.uuid}"
-    @cache.write(key, "bar")
-
-    other_key = SecureRandom.uuid
-    @cache.write(other_key, SecureRandom.alphanumeric)
-    @cache.delete_matched(key)
-    assert_not @cache.exist?(key)
-    assert @cache.exist?(other_key)
-  end
-
-  test "deletes when more items than batch size" do
-    prefix = SecureRandom.alphanumeric
-
-    keys = 5.times.map { "#{prefix}#{SecureRandom.uuid}" }
-    keys.each { |key| @cache.write(key, "bar") }
-
-    other_key = SecureRandom.uuid
-    @cache.write(other_key, SecureRandom.alphanumeric)
-
-    @cache.delete_matched("#{prefix}%", batch_size: 2)
-    keys.each { |key| assert_not @cache.exist?(key) }
-
-    assert @cache.exist?(other_key)
-  end
-
-  test "fails when starts with %" do
-    assert_raise ArgumentError do
-      @cache.delete_matched("%foo")
-    end
-  end
-
-  test "fails when starts with _" do
-    assert_raise ArgumentError do
-      @cache.delete_matched("_foo")
-    end
-  end
-
-  test "fails with regexp matchers" do
-    assert_raise ArgumentError do
-      @cache.delete_matched(/OO/i)
-    end
+    assert_raises(NotImplementedError) { @cache.delete_matched("#{prefix}%") }
   end
 end

--- a/test/unit/query_cache_test.rb
+++ b/test/unit/query_cache_test.rb
@@ -52,17 +52,4 @@ class QueryCacheTest < ActiveSupport::TestCase
       assert_equal 0, SolidCache::Entry.count
     end
   end
-
-  test "delete matches don't clear the AR cache" do
-    SolidCache::Entry.cache do
-      @cache.write("hello1", "foo")
-      @cache.write("hello2", "bar")
-      assert_equal 2, SolidCache::Entry.count
-      @cache.delete_matched("hello%")
-      assert_equal 2, SolidCache::Entry.count
-    end
-    SolidCache::Entry.uncached do
-      assert_equal 0, SolidCache::Entry.count
-    end
-  end
 end


### PR DESCRIPTION
`delete_matched` is optional, it may be removed in Rails 8.0 and relies on the index on the `key` column which will be removed in future.