### PR TITLE
Add key_hash for smaller index

### DIFF
--- a/db/migrate/20240108155507_add_key_hash_and_byte_size_to_solid_cache_entries.rb
+++ b/db/migrate/20240108155507_add_key_hash_and_byte_size_to_solid_cache_entries.rb
@@ -1,0 +1,8 @@
+class AddKeyHashAndByteSizeToSolidCacheEntries < ActiveRecord::Migration[7.1]
+  def change
+    change_table :solid_cache_entries do |t|
+      t.column :key_hash,  :integer, null: true, limit: 8
+      t.column :byte_size, :integer, null: true, limit: 4
+    end
+  end
+end

--- a/db/migrate/20240110111600_add_key_hash_and_byte_size_indexes_and_null_constraints_to_solid_cache_entries.rb
+++ b/db/migrate/20240110111600_add_key_hash_and_byte_size_indexes_and_null_constraints_to_solid_cache_entries.rb
@@ -1,0 +1,11 @@
+class AddKeyHashAndByteSizeIndexesAndNullConstraintsToSolidCacheEntries < ActiveRecord::Migration[7.1]
+  def change
+    change_table :solid_cache_entries, bulk: true do |t|
+      t.change_null :key_hash, false
+      t.change_null :byte_size, false
+      t.index  :key_hash, unique: true
+      t.index  [:key_hash, :byte_size]
+      t.index  :byte_size
+    end
+  end
+end

--- a/db/migrate/20240110111702_remove_key_index_from_solid_cache_entries.rb
+++ b/db/migrate/20240110111702_remove_key_index_from_solid_cache_entries.rb
@@ -1,0 +1,7 @@
+class RemoveKeyIndexFromSolidCacheEntries < ActiveRecord::Migration[7.1]
+  def change
+    change_table :solid_cache_entries do |t|
+      t.remove_index :key
+    end
+  end
+end

--- a/lib/solid_cache.rb
+++ b/lib/solid_cache.rb
@@ -10,6 +10,7 @@ loader.setup
 
 module SolidCache
   mattr_accessor :executor, :connects_to
+  mattr_accessor :key_hash_stage, default: :indexed
 
   def self.all_shard_keys
     all_shards_config&.keys || []

--- a/lib/solid_cache/engine.rb
+++ b/lib/solid_cache/engine.rb
@@ -13,6 +13,12 @@ module SolidCache
 
       SolidCache.executor = config.solid_cache.executor
       SolidCache.connects_to = config.solid_cache.connects_to
+      if config.solid_cache.key_hash_stage
+        unless [:ignored, :unindexed, :indexed].include?(config.solid_cache.key_hash_stage)
+          raise "ArgumentError, :key_hash_stage must be :ignored, :unindexed or :indexed"
+        end
+        SolidCache.key_hash_stage = config.solid_cache.key_hash_stage
+      end
     end
 
     config.after_initialize do

--- a/test/dummy/db/primary_shard_one_schema.rb
+++ b/test/dummy/db/primary_shard_one_schema.rb
@@ -10,12 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_121448) do
-  create_table "solid_cache_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2024_01_10_111702) do
+  create_table "solid_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
-    t.binary "value", size: :long, null: false
+    t.binary "value", limit: 536870912, null: false
     t.datetime "created_at", null: false
-    t.index ["key"], name: "index_solid_cache_entries_on_key", unique: true
+    t.integer "key_hash", limit: 8, null: false
+    t.integer "byte_size", limit: 4, null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
 end

--- a/test/dummy/db/primary_shard_two_schema.rb
+++ b/test/dummy/db/primary_shard_two_schema.rb
@@ -10,12 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_121448) do
-  create_table "solid_cache_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2024_01_10_111702) do
+  create_table "solid_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
-    t.binary "value", size: :long, null: false
+    t.binary "value", limit: 536870912, null: false
     t.datetime "created_at", null: false
-    t.index ["key"], name: "index_solid_cache_entries_on_key", unique: true
+    t.integer "key_hash", limit: 8, null: false
+    t.integer "byte_size", limit: 4, null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,12 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_121448) do
-  create_table "solid_cache_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2024_01_10_111702) do
+  create_table "solid_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
-    t.binary "value", size: :long, null: false
+    t.binary "value", limit: 536870912, null: false
     t.datetime "created_at", null: false
-    t.index ["key"], name: "index_solid_cache_entries_on_key", unique: true
+    t.integer "key_hash", limit: 8, null: false
+    t.integer "byte_size", limit: 4, null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
 end

--- a/test/dummy/db/secondary_shard_one_schema.rb
+++ b/test/dummy/db/secondary_shard_one_schema.rb
@@ -10,12 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_121448) do
-  create_table "solid_cache_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2024_01_10_111702) do
+  create_table "solid_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
-    t.binary "value", size: :long, null: false
+    t.binary "value", limit: 536870912, null: false
     t.datetime "created_at", null: false
-    t.index ["key"], name: "index_solid_cache_entries_on_key", unique: true
+    t.integer "key_hash", limit: 8, null: false
+    t.integer "byte_size", limit: 4, null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
 end

--- a/test/dummy/db/secondary_shard_two_schema.rb
+++ b/test/dummy/db/secondary_shard_two_schema.rb
@@ -10,12 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_121448) do
-  create_table "solid_cache_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2024_01_10_111702) do
+  create_table "solid_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
-    t.binary "value", size: :long, null: false
+    t.binary "value", limit: 536870912, null: false
     t.datetime "created_at", null: false
-    t.index ["key"], name: "index_solid_cache_entries_on_key", unique: true
+    t.integer "key_hash", limit: 8, null: false
+    t.integer "byte_size", limit: 4, null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
 end

--- a/upgrading_to_version_0.4.x.md
+++ b/upgrading_to_version_0.4.x.md
@@ -1,0 +1,85 @@
+# Upgrading to version 0.4.x
+
+The database schema has been updated from v0.4.0 onwards, so you'll need to follow the upgrade steps if you have used v0.3.x or lower.
+
+## Why has the schema changed?
+
+There are two new changes in v0.4.x.
+
+1. Using a `key_hash` index instead of a `key` index. `key_hash` is a new 64 bit integer column derived from the SHA256 hash of the key.
+   We'll store this value in the database and query by it. An index on a 64 bit integer is much more compact than one on a
+   1K binary blob, so this will be easier for the database to keep in memory.
+2. We'll store and index a new `byte_size` column. This stores the size of the row in bytes, and allow us to generate an estimate of
+   the cache size by sampling the data.
+
+## What will I need to do?
+
+1. Update your app to use v0.4.x. This version will work with the old and new schemas
+2. Follow the migration steps detailed below to update your schema
+3. Now you should be good to upgrade to future versions
+
+## Upgrade steps
+
+1. Upgrade to gem version v0.4.x. At the same time set this in your config:
+
+   ```
+     config.solid_cache.key_hash_stage = :ignored
+   ```
+
+2. Install and run the first migration (AddKeyHashAndByteSizeToSolidCacheEntries)
+
+   This adds the new columns.
+
+3. Update your config
+
+   ```
+     config.solid_cache.key_hash_stage = :unindexed
+   ```
+   Now the application will be populating those columns.
+
+4. Prepare the data
+
+   We will be adding not null constraints and unique indexes in the following step so we need to make sure that there are no null
+   values. The easiest thing to do here is to truncate the data if your app can handle restarting with a fresh cache.
+
+   Otherwise you'll need to run a script to backfill the missing values.
+
+5. Install and run the second migration (AddKeyHashAndByteSizeIndexesAndNullConstraintsToSolidCacheEntries)
+
+   If you truncated the data in the previous step this should run quickly. If not and you have a large table it could take a while.
+
+   If you have a process for online schema changes for large tables (pt-online-schema-change, gh-ost etc) you may need to use that here.
+
+6. Update your config
+
+   ```
+     config.solid_cache.key_hash_stage = :indexed # this is the default so you can also remove it instead
+   ```
+
+   Now we will be querying the data by the new `key_hash` column
+
+7. Install and run the final migration (RemoveKeyIndexFromSolidCacheEntries)
+
+   This will remove the old index on `key`.
+
+## Backfill script
+
+The migration will be much easier if you truncate the cache, but if that's not possible this snippet should populate the missing columns:
+
+```
+def populate_key_hash_and_byte_size(from_id: nil, to_id: nil, batch_size: 1000, pause: 0)
+  SolidCache::Entry.where(id: (from_id..to_id)).find_in_batches(batch_size: batch_size) do |entries|
+    updates = entries.map { |entry| { key: entry.key, value: entry.value } }
+
+    SolidCache::Entry.write_multi(updates)
+    sleep pause unless pause.zero?
+
+    puts "Updated to SolidCache::Entry##{entries.last.id}"
+  end
+end
+```
+
+## What if I am starting with v0.4.x?
+
+If you are starting with v0.4.x or later you don't need to follow the upgrade steps. Install and apply all the migrations together and you
+should be good to go.


### PR DESCRIPTION
This adds a key_hash column to the solid_cache_entries table. This column is a 64-bit integer that is a truncated SHA256 hash of the key. This allows us to use a smaller index than the 1024 byte key column.

The byte_size column is also added to the table. This is the size of the value in bytes. This is for a separate feature but is included in this commit to piggy back on the migrations.

The migrations themselves are split into three steps. This allows existing tables to be migrated without downtime.

There is a new configuration field `key_hash_stage` that can be set to `:ignored`, `:unindexed` or `:indexed`. This controls how the key_hash column is used and should be set as the migrations are completed.

The default is :indexed, which is what is required for fresh installations of solid_cache. In this case you can apply all three migrations at the same time.

In the case of an existing setup however, the steps are:

1. Install the new gem, install the migrations and set `config.solid_cache.key_hash_stage = :ignored`
2. Run the first migration, which adds the new columns
3. Update `config.solid_cache.key_hash_stage = :unindexed`
4. Backfill or truncate the table
5. Run the second migration, which adds the indexes and null constraints
6. Update `config.solid_cache.key_hash_stage = :indexed`
7. Run the third migration, which removes the old key index

For later versions of the gem we'll assume that the key_hash column exists and the `config.solid_cache.key_hash_stage`. We'll also squash the migrations into a single file.