### PR TITLE
Expire the cache by size

### DIFF
--- a/app/jobs/solid_cache/expiry_job.rb
+++ b/app/jobs/solid_cache/expiry_job.rb
@@ -2,9 +2,9 @@
 
 module SolidCache
   class ExpiryJob < ActiveJob::Base
-    def perform(count, shard: nil, max_age:, max_entries:)
+    def perform(count, shard: nil, max_age: nil, max_entries: nil, max_size: nil)
       Record.with_shard(shard) do
-        Entry.expire(count, max_age: max_age, max_entries: max_entries)
+        Entry.expire(count, max_age: max_age, max_entries: max_entries, max_size: max_size)
       end
     end
   end

--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -2,13 +2,15 @@
 
 module SolidCache
   class Entry < Record
-    include Expiration
+    include Expiration, Size
 
     ID_BYTE_SIZE = 8
     CREATED_AT_BYTE_SIZE = 8
     KEY_HASH_BYTE_SIZE = 8
     VALUE_BYTE_SIZE = 4
     FIXED_SIZE_COLUMNS_BYTE_SIZE = ID_BYTE_SIZE + CREATED_AT_BYTE_SIZE + KEY_HASH_BYTE_SIZE + VALUE_BYTE_SIZE
+
+    KEY_HASH_ID_RANGE = -(2**63)..(2**63 - 1)
 
     class << self
       def write(key, value)
@@ -60,6 +62,12 @@ module SolidCache
 
       def decrement(key, amount)
         increment(key, -amount)
+      end
+
+      def id_range
+        uncached do
+          pick(Arel.sql("max(id) - min(id) + 1")) || 0
+        end
       end
 
       private

--- a/app/models/solid_cache/entry/size.rb
+++ b/app/models/solid_cache/entry/size.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module SolidCache
+  class Entry
+    # # Cache size estimation
+    #
+    # We store the size of each cache row in the byte_size field. This allows us to estimate the size of the cache
+    # by sampling those rows.
+    #
+    # To reduce the effect of outliers though we'll grab the N largest rows, and add their size to a sampled based
+    # estimate of the size of the remaining rows.
+    #
+    # ## Outliers
+    #
+    # There is an index on the byte_size column, so we can efficiently grab the N largest rows. We also grab the
+    # minimum byte_size of those rows, which we'll use as a cutoff for the non outlier sampling.
+    #
+    # ## Sampling
+    #
+    # To efficiently sample the data we use the key_hash column, which is a random 64 bit integer. There's an index
+    # on key_hash and byte_size so we can grab a sum of the byte_sizes in a range of key_hash directly from that
+    # index.
+    #
+    # To decide how big the range should be, we use the difference between the smallest and largest database IDs as
+    # an estimate of the number of rows in the table. This should be a good estimate, because we delete rows in ID order
+    #
+    # We then calculate the fraction of the rows we want to sample by dividing the sample size by the estimated number
+    # of rows.
+    #
+    # The we grab the byte_size sum of the rows in the range of key_hash values excluding any rows that are larger than
+    # our minimum outlier cutoff. We then divide this by the sampling fraction to get an estimate of the size of the
+    # non outlier rows
+    #
+    # ## Equations
+    #
+    #  Given N samples and a key_hash range of Kmin..Kmax
+    #
+    #    outliers_cutoff              OC = min(byte_size of N largest rows)
+    #    outliers_size                OS = sum(byte_size of N largest rows)
+    #
+    #    estimated number of rows     R = max(ID) - min(ID) + 1
+    #    sample_fraction              F = N / R
+    #    sample_range_size            S = (Kmax - Kmin) * F
+    #    sample range is              K1..K2 where K1 = Kmin + rand(Kmax - S) and K2 = K1 + S
+    #
+    #    non_outlier_sample_size      NSS = sum(byte_size of rows in key_hash range K1..K2 where byte_size <= OC)
+    #    non_outlier_estimated_size   NES = NSS / F
+    #    estimated_size               ES = OS + NES
+    module Size
+      extend ActiveSupport::Concern
+
+      included do
+        scope :largest_byte_sizes, -> (limit) { from(order(byte_size: :desc).limit(limit).select(:byte_size)) }
+        scope :in_key_hash_range, -> (range) { where(key_hash: range) }
+        scope :up_to_byte_size, -> (cutoff) { where("byte_size <= ?", cutoff) }
+      end
+
+      class_methods do
+        def estimated_size(samples: SolidCache.configuration.size_estimate_samples)
+          Estimate.new(samples: samples).estimated_size
+        end
+      end
+
+      class Estimate
+        attr_reader :samples
+
+        def initialize(samples:)
+          @samples = samples
+        end
+
+        def estimated_size
+          outliers_size + non_outlier_estimated_size
+        end
+
+        private
+          def outliers_size
+            outliers_size_and_cutoff[0]
+          end
+
+          def outliers_cutoff
+            outliers_size_and_cutoff[1]
+          end
+
+          def outliers_size_and_cutoff
+            @outlier_size_and_cutoff ||= Entry.uncached do
+              sum, min = Entry.largest_byte_sizes(samples).pick(Arel.sql("sum(byte_size), min(byte_size)"))
+              sum ? [sum, min] : [0, nil]
+            end
+          end
+
+          def non_outlier_estimated_size
+            @non_outlier_estimated_size ||= sampled_fraction.zero? ? 0 : (sampled_non_outlier_size / sampled_fraction).round
+          end
+
+          def sampled_fraction
+            @sampled_fraction ||=
+              if max_records <= samples
+                0
+              else
+                [samples.to_f / (max_records - samples), 1].min
+              end
+          end
+
+          def max_records
+            @max_records ||= Entry.id_range
+          end
+
+          def sampled_non_outlier_size
+            @sampled_non_outlier_size ||= Entry.uncached do
+              Entry.in_key_hash_range(sample_range).up_to_byte_size(outliers_cutoff).sum(:byte_size)
+            end
+          end
+
+          def sample_range
+            if sampled_fraction == 1
+              key_hash_range
+            else
+              start = rand(key_hash_range.begin..(key_hash_range.end - sample_range_size))
+              start..(start + sample_range_size)
+            end
+          end
+
+          def key_hash_range
+            Entry::KEY_HASH_ID_RANGE
+          end
+
+          def sample_range_size
+            @sample_range_size ||= (key_hash_range.size * sampled_fraction).to_i
+          end
+      end
+    end
+  end
+end

--- a/lib/solid_cache/configuration.rb
+++ b/lib/solid_cache/configuration.rb
@@ -2,11 +2,11 @@
 
 module SolidCache
   class Configuration
-    attr_reader :store_options, :connects_to, :key_hash_stage, :executor
+    attr_reader :store_options, :connects_to, :executor, :size_estimate_samples
 
-    def initialize(store_options: {}, database: nil, databases: nil, connects_to: nil, key_hash_stage: :indexed, executor: nil)
+    def initialize(store_options: {}, database: nil, databases: nil, connects_to: nil, executor: nil, size_estimate_samples: 10_000)
       @store_options = store_options
-      @key_hash_stage = key_hash_stage
+      @size_estimate_samples = size_estimate_samples
       @executor = executor
       set_connects_to(database: database, databases: databases, connects_to: connects_to)
     end

--- a/lib/solid_cache/engine.rb
+++ b/lib/solid_cache/engine.rb
@@ -11,12 +11,15 @@ module SolidCache
     initializer "solid_cache.config" do |app|
       app.paths.add "config/solid_cache", with: ENV["SOLID_CACHE_CONFIG"] || "config/solid_cache.yml"
 
+      options = {}
       if (config_path = Pathname.new(app.config.paths["config/solid_cache"].first)).exist?
         options = app.config_for(config_path).to_h.deep_symbolize_keys
-        options[:connects_to] = config.solid_cache.connects_to if config.solid_cache.connects_to
-
-        SolidCache.configuration = SolidCache::Configuration.new(**options)
       end
+
+      options[:connects_to] = config.solid_cache.connects_to if config.solid_cache.connects_to
+      options[:size_estimate_samples] = config.solid_cache.size_estimate_samples if config.solid_cache.size_estimate_samples
+
+      SolidCache.configuration = SolidCache::Configuration.new(**options)
 
       if config.solid_cache.key_hash_stage
         ActiveStorage.deprecator.warn("config.solid_cache.key_hash_stage is deprecated and has no effect.")

--- a/test/models/solid_cache/entry/size_test.rb
+++ b/test/models/solid_cache/entry/size_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module SolidCache
+  class EntrySizeTest < ActiveSupport::TestCase
+    test "write and read cache entries" do
+      assert_equal 0, Entry.estimated_size
+    end
+
+    test "gets exact estimate when samples sizes are big enough" do
+      write_entries(value_lengths: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ])
+
+      assert_equal 415, Entry.estimated_size(samples: 12)
+      assert_equal 415, Entry.estimated_size(samples: 10)
+      assert_equal 456, Entry.estimated_size(samples: 6)
+      assert_equal 457, Entry.estimated_size(samples: 5)
+    end
+
+    test "test larger sample estimates" do
+      values_lengths = with_fixed_srand(1) { 1000.times.map { (rand**2 * 1000).to_i } }
+      write_entries(value_lengths: values_lengths)
+
+      assert_equal 369257, Entry.estimated_size(samples: 1000)
+      assert_equal 369550, Entry.estimated_size(samples: 500)
+      with_fixed_srand(1) { assert_equal 383576, Entry.estimated_size(samples: 100) }
+      with_fixed_srand(1) { assert_equal 357109, Entry.estimated_size(samples: 50) }
+      with_fixed_srand(1) { assert_equal 326614, Entry.estimated_size(samples: 10) }
+    end
+
+    test "test with gaps in records estimates" do
+      values_lengths = with_fixed_srand(1) { 1000.times.map { (rand**2 * 1000).to_i } }
+      write_entries(value_lengths: values_lengths)
+      first_mod = Entry.first.id % 3
+      Entry.where("id % 3 = #{first_mod}").delete_all
+
+      assert_equal 249940, Entry.estimated_size(samples: 1000)
+      assert_equal 250037, Entry.estimated_size(samples: 500)
+      with_fixed_srand(1) { assert_equal 249354, Entry.estimated_size(samples: 334) }
+      with_fixed_srand(1) { assert_equal 267523, Entry.estimated_size(samples: 100) }
+      with_fixed_srand(1) { assert_equal 257970, Entry.estimated_size(samples: 50) }
+      with_fixed_srand(1) { assert_equal 203365, Entry.estimated_size(samples: 10) }
+    end
+
+    test "test with more gaps in records estimates" do
+      values_lengths = with_fixed_srand(1) { 1000.times.map { (rand**2 * 1000).to_i } }
+      write_entries(value_lengths: values_lengths)
+      first_mod = Entry.first.id % 4
+      Entry.where("id % 4 != #{first_mod}").delete_all
+
+      assert_equal 92304, Entry.estimated_size(samples: 1000)
+      assert_equal 92592, Entry.estimated_size(samples: 500)
+      with_fixed_srand(1) { assert_equal 92519, Entry.estimated_size(samples: 250) }
+      with_fixed_srand(1) { assert_equal 95475, Entry.estimated_size(samples: 100) }
+      with_fixed_srand(1) { assert_equal 101601, Entry.estimated_size(samples: 50) }
+      with_fixed_srand(1) { assert_equal 13362, Entry.estimated_size(samples: 10) }
+    end
+
+    test "overestimate when all samples sizes are the same" do
+      # This is a pathological case where the bytes sizes are all the same, and
+      # the outliers are not outliers at all. Ensure we over rather than under
+      # estimate in this case.
+      write_entries(value_lengths: [1] * 1000)
+
+      assert_equal 37000, Entry.estimated_size(samples: 1000)
+      assert_equal 73963, Entry.estimated_size(samples: 999)
+      assert_equal 55500, Entry.estimated_size(samples: 500)
+      with_fixed_srand(1) { assert_equal 67648, Entry.estimated_size(samples: 6) }
+      with_fixed_srand(1) { assert_equal 81178, Entry.estimated_size(samples: 5) }
+    end
+
+    private
+      def write_entries(value_lengths:)
+        Entry.write_multi(value_lengths.map.with_index { |value_length, index| { key: "key#{index.to_s.rjust(5, "0")}", value: "a" * value_length } })
+      end
+
+      def with_fixed_srand(seed)
+        old_srand = srand(seed)
+        yield
+      ensure
+        srand(old_srand)
+      end
+  end
+end

--- a/test/unit/solid_cache_test.rb
+++ b/test/unit/solid_cache_test.rb
@@ -57,11 +57,12 @@ class SolidCacheFailsafeTest < ActiveSupport::TestCase
   end
 
   def emulating_unavailability
+    wait_for_background_tasks(@cache)
     stub_matcher = ActiveRecord::Base.connection.class.any_instance
     stub_matcher.stubs(:exec_query).raises(ActiveRecord::StatementInvalid)
     stub_matcher.stubs(:internal_exec_query).raises(ActiveRecord::StatementInvalid)
     stub_matcher.stubs(:exec_delete).raises(ActiveRecord::StatementInvalid)
-    yield ActiveSupport::Cache::SolidCacheStore.new(namespace: @namespace)
+    yield lookup_store(namespace: @namespace)
   ensure
     stub_matcher.unstub(:exec_query)
     stub_matcher.unstub(:internal_exec_query)
@@ -84,11 +85,12 @@ class SolidCacheRaisingTest < ActiveSupport::TestCase
   end
 
   def emulating_unavailability
+    wait_for_background_tasks(@cache)
     stub_matcher = ActiveRecord::Base.connection.class.any_instance
     stub_matcher.stubs(:exec_query).raises(ActiveRecord::StatementInvalid)
     stub_matcher.stubs(:internal_exec_query).raises(ActiveRecord::StatementInvalid)
     stub_matcher.stubs(:exec_delete).raises(ActiveRecord::StatementInvalid)
-    yield ActiveSupport::Cache::SolidCacheStore.new(namespace: @namespace,
+    yield lookup_store(namespace: @namespace,
       error_handler: ->(method:, returning:, exception:) { raise exception })
   ensure
     stub_matcher.unstub(:exec_query)


### PR DESCRIPTION
Add a new option to the cache to limit it by size. The size is estimated by sampling the `byte_size` column of the cache entries.

The size estimation firsts loads the `byte_size` of the N largest records ("the outliers"). We also grab the smallest size in that list to use as a cutoff for estimating the size of the remaining records ("the non-outliers").

The estimate of the size of the non-outliers is calculated by sampling a random portion of the records. To quickly sample the records we use the index on `key_hash` and `byte_size`.

We estimate how many records we'll need to sample by dividing the sample size by the estimated record count. This is our sample fraction.

We choose a random range of `key_hash` values the size of our sample fraction. We then sum the `byte_size` of the records in that range that do not exceed the cutoff and divide this value by the sample fraction.

This gives up our non-outlier estimate which we add to the outlier total for our estimated size.

On Hey, so far we see this giving an estimate that it +/-5% of the actual total with 10,000 samples. It takes about 6ms (client side) to calculate the estimate. Different cache distributions and sizes may give different results.

Compared to just random sampling, adding the separate outlier check reduces the standard deviation of the guesses by about 25%, with almost exactly the same mean value. It will generally help in cases where there are a few very large records.

Because we resample every time we are deciding whether to expire records we should be fairly resilient to the odd poor estimate.