### PR TITLE
Failsafe no key_hash_stage

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -99,7 +99,7 @@ module SolidCache
         end
 
         def key_hash_indexed?
-          SolidCache.key_hash_stage == :indexed
+          key_hash? && SolidCache.key_hash_stage == :indexed
         end
 
         def lookup_column


### PR DESCRIPTION
Check for whether the key_hash column exists in case of upgrades to the new version without setting `SolidCache.key_hash_stage == :ignored`.