### PR TITLE
Fix RemoveKeyIndexFromSolidCacheEntries migration

### DIFF
--- a/db/migrate/20240110111702_remove_key_index_from_solid_cache_entries.rb
+++ b/db/migrate/20240110111702_remove_key_index_from_solid_cache_entries.rb
@@ -1,7 +1,7 @@
 class RemoveKeyIndexFromSolidCacheEntries < ActiveRecord::Migration[7.1]
   def change
     change_table :solid_cache_entries do |t|
-      t.remove_index :key
+      t.remove_index :key, unique: true
     end
   end
 end


### PR DESCRIPTION
Currently, the `RemoveKeyIndexFromSolidCacheEntries` migration isn't reversible because `unique: true` is missing from `remove_index`.