### PR TITLE
Load config before cache initialization

### DIFF
--- a/lib/solid_cache/engine.rb
+++ b/lib/solid_cache/engine.rb
@@ -8,7 +8,7 @@ module SolidCache
 
     config.solid_cache = ActiveSupport::OrderedOptions.new
 
-    initializer "solid_cache.config" do |app|
+    initializer "solid_cache.config", before: :initialize_cache do |app|
       app.paths.add "config/solid_cache", with: ENV["SOLID_CACHE_CONFIG"] || "config/solid_cache.yml"
 
       if (config_path = Pathname.new(app.config.paths["config/solid_cache"].first)).exist?

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :solid_cache_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/test/unit/rails_cache_test.rb
+++ b/test/unit/rails_cache_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RailsCacheTest < ActiveSupport::TestCase
+  test "reads cache yml config" do
+    assert_equal 3600, Rails.cache.primary_cluster.max_age
+  end
+end


### PR DESCRIPTION
Ensure that we have loaded solid_cache.yml before the cache store is initialized.