### PR TITLE
Fix for incorrect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ production: &production
     max_entries: <%= 256.gigabytes %>
 ```
 
-For the full list of keys for `store_options` see [Cache configuration](#cache_configuration). Any options passed to the cache lookup will overwrite those specified here.
+For the full list of keys for `store_options` see [Cache configuration](#cache-configuration). Any options passed to the cache lookup will overwrite those specified here.
 
 #### Connection configuration
 


### PR DESCRIPTION
Hi team! 
I just fixed the Cache Configuration link in README because it was written incorrectly.
(Existing links do not point to cache configuration section properly)