### PR TITLE
Use a moving average of cache size estimates

### DIFF
--- a/app/models/solid_cache/entry/size.rb
+++ b/app/models/solid_cache/entry/size.rb
@@ -2,50 +2,6 @@
 
 module SolidCache
   class Entry
-    # # Cache size estimation
-    #
-    # We store the size of each cache row in the byte_size field. This allows us to estimate the size of the cache
-    # by sampling those rows.
-    #
-    # To reduce the effect of outliers though we'll grab the N largest rows, and add their size to a sampled based
-    # estimate of the size of the remaining rows.
-    #
-    # ## Outliers
-    #
-    # There is an index on the byte_size column, so we can efficiently grab the N largest rows. We also grab the
-    # minimum byte_size of those rows, which we'll use as a cutoff for the non outlier sampling.
-    #
-    # ## Sampling
-    #
-    # To efficiently sample the data we use the key_hash column, which is a random 64 bit integer. There's an index
-    # on key_hash and byte_size so we can grab a sum of the byte_sizes in a range of key_hash directly from that
-    # index.
-    #
-    # To decide how big the range should be, we use the difference between the smallest and largest database IDs as
-    # an estimate of the number of rows in the table. This should be a good estimate, because we delete rows in ID order
-    #
-    # We then calculate the fraction of the rows we want to sample by dividing the sample size by the estimated number
-    # of rows.
-    #
-    # The we grab the byte_size sum of the rows in the range of key_hash values excluding any rows that are larger than
-    # our minimum outlier cutoff. We then divide this by the sampling fraction to get an estimate of the size of the
-    # non outlier rows
-    #
-    # ## Equations
-    #
-    #  Given N samples and a key_hash range of Kmin..Kmax
-    #
-    #    outliers_cutoff              OC = min(byte_size of N largest rows)
-    #    outliers_size                OS = sum(byte_size of N largest rows)
-    #
-    #    estimated number of rows     R = max(ID) - min(ID) + 1
-    #    sample_fraction              F = N / R
-    #    sample_range_size            S = (Kmax - Kmin) * F
-    #    sample range is              K1..K2 where K1 = Kmin + rand(Kmax - S) and K2 = K1 + S
-    #
-    #    non_outlier_sample_size      NSS = sum(byte_size of rows in key_hash range K1..K2 where byte_size <= OC)
-    #    non_outlier_estimated_size   NES = NSS / F
-    #    estimated_size               ES = OS + NES
     module Size
       extend ActiveSupport::Concern
 
@@ -57,76 +13,8 @@ module SolidCache
 
       class_methods do
         def estimated_size(samples: SolidCache.configuration.size_estimate_samples)
-          Estimate.new(samples: samples).estimated_size
+          MovingAverageEstimate.new(samples: samples).size
         end
-      end
-
-      class Estimate
-        attr_reader :samples
-
-        def initialize(samples:)
-          @samples = samples
-        end
-
-        def estimated_size
-          outliers_size + non_outlier_estimated_size
-        end
-
-        private
-          def outliers_size
-            outliers_size_and_cutoff[0]
-          end
-
-          def outliers_cutoff
-            outliers_size_and_cutoff[1]
-          end
-
-          def outliers_size_and_cutoff
-            @outlier_size_and_cutoff ||= Entry.uncached do
-              sum, min = Entry.largest_byte_sizes(samples).pick(Arel.sql("sum(byte_size), min(byte_size)"))
-              sum ? [sum, min] : [0, nil]
-            end
-          end
-
-          def non_outlier_estimated_size
-            @non_outlier_estimated_size ||= sampled_fraction.zero? ? 0 : (sampled_non_outlier_size / sampled_fraction).round
-          end
-
-          def sampled_fraction
-            @sampled_fraction ||=
-              if max_records <= samples
-                0
-              else
-                [samples.to_f / (max_records - samples), 1].min
-              end
-          end
-
-          def max_records
-            @max_records ||= Entry.id_range
-          end
-
-          def sampled_non_outlier_size
-            @sampled_non_outlier_size ||= Entry.uncached do
-              Entry.in_key_hash_range(sample_range).up_to_byte_size(outliers_cutoff).sum(:byte_size)
-            end
-          end
-
-          def sample_range
-            if sampled_fraction == 1
-              key_hash_range
-            else
-              start = rand(key_hash_range.begin..(key_hash_range.end - sample_range_size))
-              start..(start + sample_range_size)
-            end
-          end
-
-          def key_hash_range
-            Entry::KEY_HASH_ID_RANGE
-          end
-
-          def sample_range_size
-            @sample_range_size ||= (key_hash_range.size * sampled_fraction).to_i
-          end
       end
     end
   end

--- a/app/models/solid_cache/entry/size/estimate.rb
+++ b/app/models/solid_cache/entry/size/estimate.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module SolidCache
+  class Entry
+    # # Cache size estimation
+    #
+    # We store the size of each cache row in the byte_size field. This allows us to estimate the size of the cache
+    # by sampling those rows.
+    #
+    # To reduce the effect of outliers though we'll grab the N largest rows, and add their size to a sampled based
+    # estimate of the size of the remaining rows.
+    #
+    # ## Outliers
+    #
+    # There is an index on the byte_size column, so we can efficiently grab the N largest rows. We also grab the
+    # minimum byte_size of those rows, which we'll use as a cutoff for the non outlier sampling.
+    #
+    # ## Sampling
+    #
+    # To efficiently sample the data we use the key_hash column, which is a random 64 bit integer. There's an index
+    # on key_hash and byte_size so we can grab a sum of the byte_sizes in a range of key_hash directly from that
+    # index.
+    #
+    # To decide how big the range should be, we use the difference between the smallest and largest database IDs as
+    # an estimate of the number of rows in the table. This should be a good estimate, because we delete rows in ID order
+    #
+    # We then calculate the fraction of the rows we want to sample by dividing the sample size by the estimated number
+    # of rows.
+    #
+    # The we grab the byte_size sum of the rows in the range of key_hash values excluding any rows that are larger than
+    # our minimum outlier cutoff. We then divide this by the sampling fraction to get an estimate of the size of the
+    # non outlier rows
+    #
+    # ## Equations
+    #
+    #  Given N samples and a key_hash range of Kmin..Kmax
+    #
+    #    outliers_cutoff              OC = min(byte_size of N largest rows)
+    #    outliers_size                OS = sum(byte_size of N largest rows)
+    #
+    #    estimated number of rows     R = max(ID) - min(ID) + 1
+    #    sample_fraction              F = N / R
+    #    sample_range_size            S = (Kmax - Kmin) * F
+    #    sample range is              K1..K2 where K1 = Kmin + rand(Kmax - S) and K2 = K1 + S
+    #
+    #    non_outlier_sample_size      NSS = sum(byte_size of rows in key_hash range K1..K2 where byte_size <= OC)
+    #    non_outlier_estimated_size   NES = NSS / F
+    #    estimated_size               ES = OS + NES
+    module Size
+      class Estimate
+        attr_reader :samples, :max_records
+
+        def initialize(samples:)
+          @samples = samples
+          @max_records ||= Entry.id_range
+        end
+
+        def size
+          outliers_size + non_outlier_estimated_size
+        end
+
+        def exact?
+          outliers_count < samples || sampled_fraction == 1
+        end
+
+        private
+          def outliers_size
+            outliers_size_count_and_cutoff[0]
+          end
+
+          def outliers_count
+            outliers_size_count_and_cutoff[1]
+          end
+
+          def outliers_cutoff
+            outliers_size_count_and_cutoff[2]
+          end
+
+          def outliers_size_count_and_cutoff
+            @outlier_size_and_cutoff ||= Entry.uncached do
+              sum, count, min = Entry.largest_byte_sizes(samples).pick(Arel.sql("sum(byte_size), count(*), min(byte_size)"))
+              sum ? [sum, count, min] : [0, 0, nil]
+            end
+          end
+
+          def non_outlier_estimated_size
+            @non_outlier_estimated_size ||= sampled_fraction.zero? ? 0 : (sampled_non_outlier_size / sampled_fraction).round
+          end
+
+          def sampled_fraction
+            @sampled_fraction ||=
+              if max_records <= samples
+                0
+              else
+                [samples.to_f / (max_records - samples), 1].min
+              end
+          end
+
+          def sampled_non_outlier_size
+            @sampled_non_outlier_size ||= Entry.uncached do
+              Entry.in_key_hash_range(sample_range).up_to_byte_size(outliers_cutoff).sum(:byte_size)
+            end
+          end
+
+          def sample_range
+            if sampled_fraction == 1
+              key_hash_range
+            else
+              start = rand(key_hash_range.begin..(key_hash_range.end - sample_range_size))
+              start..(start + sample_range_size)
+            end
+          end
+
+          def key_hash_range
+            Entry::KEY_HASH_ID_RANGE
+          end
+
+          def sample_range_size
+            @sample_range_size ||= (key_hash_range.size * sampled_fraction).to_i
+          end
+      end
+    end
+  end
+end

--- a/app/models/solid_cache/entry/size/moving_average_estimate.rb
+++ b/app/models/solid_cache/entry/size/moving_average_estimate.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module SolidCache
+  class Entry
+    module Size
+      # Moving averate cache size estimation
+      #
+      # To reduce variablitity in the cache size estimate, we'll use a moving average of the previous 20 estimates.
+      # The estimates are stored directly in the cache, under the "__solid_cache_entry_size_moving_average_estimates" key.
+      #
+      # We'll remove the largest and smallest estimates, and then average remaining ones.
+      class MovingAverageEstimate
+        ESTIMATES_KEY = "__solid_cache_entry_size_moving_average_estimates"
+        MAX_RETAINED_ESTIMATES = 50
+        TARGET_SAMPLED_FRACTION = 0.0005
+
+        attr_reader :samples, :size
+        delegate :exact?, to: :estimate
+
+        def initialize(samples:)
+          @samples = samples
+          @estimate = Estimate.new(samples: samples)
+          values = latest_values
+          @size = (values.sum / values.size.to_f).round
+          write_values(values)
+        end
+
+        private
+          attr_reader :estimate
+
+          def previous_values
+            Entry.read(ESTIMATES_KEY).presence&.split("|")&.map(&:to_i) || []
+          end
+
+          def latest_value
+            estimate.size
+          end
+
+          def latest_values
+            (previous_values + [latest_value]).last(retained_estimates)
+          end
+
+          def write_values(values)
+            Entry.write(ESTIMATES_KEY, values.join("|"))
+          end
+
+          def retained_estimates
+            [retained_estimates_for_target_fraction, MAX_RETAINED_ESTIMATES].min
+          end
+
+          def retained_estimates_for_target_fraction
+            (estimate.max_records / samples * TARGET_SAMPLED_FRACTION).floor + 1
+          end
+      end
+    end
+  end
+end

--- a/test/models/solid_cache/entry/size/estimate_test.rb
+++ b/test/models/solid_cache/entry/size/estimate_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module SolidCache
+  class EntrySizeEstimateTest < ActiveSupport::TestCase
+    test "write and read cache entries" do
+      assert_equal 0, estimate(samples: 10)
+    end
+
+    test "gets exact estimate when samples sizes are big enough" do
+      write_entries(value_lengths: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ])
+
+      assert_equal 415, estimate(samples: 12)
+      assert_equal 415, estimate(samples: 10)
+      assert_equal 456, estimate(samples: 6)
+      assert_equal 457, estimate(samples: 5)
+    end
+
+    test "test larger sample estimates" do
+      values_lengths = with_fixed_srand(1) { 1000.times.map { (rand**2 * 1000).to_i } }
+      write_entries(value_lengths: values_lengths)
+
+      assert_equal 369257, estimate(samples: 1000)
+      assert_equal 369550, estimate(samples: 500)
+      with_fixed_srand(1) { assert_equal 383576, estimate(samples: 100) }
+      with_fixed_srand(1) { assert_equal 357109, estimate(samples: 50) }
+      with_fixed_srand(1) { assert_equal 326614, estimate(samples: 10) }
+    end
+
+    test "test with gaps in records estimates" do
+      values_lengths = with_fixed_srand(1) { 1000.times.map { (rand**2 * 1000).to_i } }
+      write_entries(value_lengths: values_lengths)
+      first_mod = Entry.first.id % 3
+      Entry.where("id % 3 = #{first_mod}").delete_all
+
+      assert_equal 249940, estimate(samples: 1000)
+      assert_equal 250037, estimate(samples: 500)
+      with_fixed_srand(1) { assert_equal 249354, estimate(samples: 334) }
+      with_fixed_srand(1) { assert_equal 267523, estimate(samples: 100) }
+      with_fixed_srand(1) { assert_equal 257970, estimate(samples: 50) }
+      with_fixed_srand(1) { assert_equal 203365, estimate(samples: 10) }
+    end
+
+    test "test with more gaps in records estimates" do
+      values_lengths = with_fixed_srand(1) { 1000.times.map { (rand**2 * 1000).to_i } }
+      write_entries(value_lengths: values_lengths)
+      first_mod = Entry.first.id % 4
+      Entry.where("id % 4 != #{first_mod}").delete_all
+
+      assert_equal 92304, estimate(samples: 1000)
+      assert_equal 92592, estimate(samples: 500)
+      with_fixed_srand(1) { assert_equal 92519, estimate(samples: 250) }
+      with_fixed_srand(1) { assert_equal 95475, estimate(samples: 100) }
+      with_fixed_srand(1) { assert_equal 101601, estimate(samples: 50) }
+      with_fixed_srand(1) { assert_equal 13362, estimate(samples: 10) }
+    end
+
+    test "overestimate when all samples sizes are the same" do
+      # This is a pathological case where the bytes sizes are all the same, and
+      # the outliers are not outliers at all. Ensure we over rather than under
+      # estimate in this case.
+      write_entries(value_lengths: [1] * 1000)
+
+      assert_equal 37000, estimate(samples: 1000)
+      assert_equal 73963, estimate(samples: 999)
+      assert_equal 55500, estimate(samples: 500)
+      with_fixed_srand(1) { assert_equal 67648, estimate(samples: 6) }
+      with_fixed_srand(1) { assert_equal 81178, estimate(samples: 5) }
+    end
+
+    private
+      def write_entries(value_lengths:)
+        Entry.write_multi(value_lengths.map.with_index { |value_length, index| { key: "key#{index.to_s.rjust(5, "0")}", value: "a" * value_length } })
+      end
+
+      def with_fixed_srand(seed)
+        old_srand = srand(seed)
+        yield
+      ensure
+        srand(old_srand)
+      end
+
+      def estimate(samples:)
+        Entry::Size::Estimate.new(samples: samples).size
+      end
+  end
+end

--- a/test/models/solid_cache/entry/size/moving_average_estimate_test.rb
+++ b/test/models/solid_cache/entry/size/moving_average_estimate_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module SolidCache
+  class EntrySizeMovingAverageEstimateTest < ActiveSupport::TestCase
+    test "write and read cache entries" do
+      assert_equal 0, estimate(samples: 10)
+    end
+
+    test "gets exact estimate when samples sizes are big enough" do
+      write_entries(value_lengths: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ])
+
+      estimate = Entry::Size::MovingAverageEstimate.new(samples: 12)
+      assert_predicate estimate, :exact?
+      assert_equal 415, estimate.size
+    end
+
+    test "tracks moving average" do
+      write_entries(value_lengths: 5000.times.to_a)
+
+      Entry.write Entry::Size::MovingAverageEstimate::ESTIMATES_KEY, "4637774|4754378|7588547"
+
+      with_fixed_srand(1) do
+        assert_equal 10075987, estimate(samples: 1)
+      end
+
+      assert_equal "4754378|7588547|17885035", Entry.read(Entry::Size::MovingAverageEstimate::ESTIMATES_KEY)
+    end
+
+    test "appends to moving average when less than required items" do
+      write_entries(value_lengths: 5000.times.to_a)
+
+      assert_nil Entry.read(Entry::Size::MovingAverageEstimate::ESTIMATES_KEY)
+
+      with_fixed_srand(1) { assert_equal 19872121, estimate(samples: 2) }
+
+      assert_equal "19872121", Entry.read(Entry::Size::MovingAverageEstimate::ESTIMATES_KEY)
+
+      with_fixed_srand(2) { assert_equal 11077118, estimate(samples: 2) }
+
+      assert_equal "19872121|2282115", Entry.read(Entry::Size::MovingAverageEstimate::ESTIMATES_KEY)
+    end
+
+    private
+      def write_entries(value_lengths:)
+        Entry.write_multi(value_lengths.map.with_index { |value_length, index| { key: "key#{index.to_s.rjust(5, "0")}", value: "a" * value_length } })
+      end
+
+      def with_fixed_srand(seed)
+        old_srand = srand(seed)
+        yield
+      ensure
+        srand(old_srand)
+      end
+
+      def estimate(samples:)
+        Entry::Size::MovingAverageEstimate.new(samples: samples).size
+      end
+  end
+end

--- a/test/models/solid_cache/entry/size_test.rb
+++ b/test/models/solid_cache/entry/size_test.rb
@@ -12,9 +12,8 @@ module SolidCache
       write_entries(value_lengths: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ])
 
       assert_equal 415, Entry.estimated_size(samples: 12)
-      assert_equal 415, Entry.estimated_size(samples: 10)
-      assert_equal 456, Entry.estimated_size(samples: 6)
-      assert_equal 457, Entry.estimated_size(samples: 5)
+      assert_equal 533, Entry.estimated_size(samples: 10)
+      assert_equal 537, Entry.estimated_size(samples: 6)
     end
 
     test "test larger sample estimates" do
@@ -22,10 +21,10 @@ module SolidCache
       write_entries(value_lengths: values_lengths)
 
       assert_equal 369257, Entry.estimated_size(samples: 1000)
-      assert_equal 369550, Entry.estimated_size(samples: 500)
-      with_fixed_srand(1) { assert_equal 383576, Entry.estimated_size(samples: 100) }
-      with_fixed_srand(1) { assert_equal 357109, Entry.estimated_size(samples: 50) }
-      with_fixed_srand(1) { assert_equal 326614, Entry.estimated_size(samples: 10) }
+      assert_equal 369926, Entry.estimated_size(samples: 501)
+      with_fixed_srand(1) { assert_equal 383898, Entry.estimated_size(samples: 100) }
+      with_fixed_srand(1) { assert_equal 357433, Entry.estimated_size(samples: 50) }
+      with_fixed_srand(1) { assert_equal 326934, Entry.estimated_size(samples: 10) }
     end
 
     test "test with gaps in records estimates" do
@@ -35,11 +34,11 @@ module SolidCache
       Entry.where("id % 3 = #{first_mod}").delete_all
 
       assert_equal 249940, Entry.estimated_size(samples: 1000)
-      assert_equal 250037, Entry.estimated_size(samples: 500)
-      with_fixed_srand(1) { assert_equal 249354, Entry.estimated_size(samples: 334) }
-      with_fixed_srand(1) { assert_equal 267523, Entry.estimated_size(samples: 100) }
-      with_fixed_srand(1) { assert_equal 257970, Entry.estimated_size(samples: 50) }
-      with_fixed_srand(1) { assert_equal 203365, Entry.estimated_size(samples: 10) }
+      assert_equal 250120, Entry.estimated_size(samples: 500)
+      with_fixed_srand(1) { assert_equal 249639, Entry.estimated_size(samples: 334) }
+      with_fixed_srand(1) { assert_equal 267921, Entry.estimated_size(samples: 100) }
+      with_fixed_srand(1) { assert_equal 258414, Entry.estimated_size(samples: 50) }
+      with_fixed_srand(1) { assert_equal 203756, Entry.estimated_size(samples: 10) }
     end
 
     test "test with more gaps in records estimates" do
@@ -49,11 +48,11 @@ module SolidCache
       Entry.where("id % 4 != #{first_mod}").delete_all
 
       assert_equal 92304, Entry.estimated_size(samples: 1000)
-      assert_equal 92592, Entry.estimated_size(samples: 500)
-      with_fixed_srand(1) { assert_equal 92519, Entry.estimated_size(samples: 250) }
-      with_fixed_srand(1) { assert_equal 95475, Entry.estimated_size(samples: 100) }
-      with_fixed_srand(1) { assert_equal 101601, Entry.estimated_size(samples: 50) }
-      with_fixed_srand(1) { assert_equal 13362, Entry.estimated_size(samples: 10) }
+      assert_equal 92674, Entry.estimated_size(samples: 501)
+      with_fixed_srand(1) { assert_equal 92566, Entry.estimated_size(samples: 250) }
+      with_fixed_srand(1) { assert_equal 95594, Entry.estimated_size(samples: 100) }
+      with_fixed_srand(1) { assert_equal 101852, Entry.estimated_size(samples: 50) }
+      with_fixed_srand(1) { assert_equal 13377, Entry.estimated_size(samples: 10) }
     end
 
     test "overestimate when all samples sizes are the same" do
@@ -63,10 +62,10 @@ module SolidCache
       write_entries(value_lengths: [1] * 1000)
 
       assert_equal 37000, Entry.estimated_size(samples: 1000)
-      assert_equal 73963, Entry.estimated_size(samples: 999)
-      assert_equal 55500, Entry.estimated_size(samples: 500)
-      with_fixed_srand(1) { assert_equal 67648, Entry.estimated_size(samples: 6) }
-      with_fixed_srand(1) { assert_equal 81178, Entry.estimated_size(samples: 5) }
+      assert_equal 74008, Entry.estimated_size(samples: 999)
+      assert_equal 55582, Entry.estimated_size(samples: 501)
+      with_fixed_srand(1) { assert_equal 67761, Entry.estimated_size(samples: 6) }
+      with_fixed_srand(1) { assert_equal 81304, Entry.estimated_size(samples: 5) }
     end
 
     private

--- a/test/unit/expiry_test.rb
+++ b/test/unit/expiry_test.rb
@@ -70,16 +70,16 @@ class SolidCache::ExpiryTest < ActiveSupport::TestCase
       @cache.write(default_shard_keys[0], "a" * 350)
       @cache.write(default_shard_keys[1], "a" * 350)
 
-      sleep 0.1
+      wait_for_background_tasks(@cache)
+      perform_enqueued_jobs
 
       @cache.write(default_shard_keys[2], "a" * 350)
       @cache.write(default_shard_keys[3], "a" * 350)
 
-      sleep 0.1
+      wait_for_background_tasks(@cache)
       perform_enqueued_jobs
 
-      # Two records have been deleted
-      assert_equal 1, SolidCache::Record.each_shard.sum { SolidCache::Entry.count }
+      assert_operator SolidCache::Record.each_shard.sum { SolidCache::Entry.count }, :<, 4
     end
 
     test "expires records no shards (#{expiry_method})" do


### PR DESCRIPTION
With small caches, the outlier query is very effective at reducing the
error bars on the cache size estimate. As the cache grows though, it
becomes a small % of the total cache size.

Since the entry sizes can have a long tail, the small number of large
entries in the sample query can have a big effect on the overall
estimate.

To counteract this, we'll use a moving average of the last N estimates.
The estimates will be stored directly in the cache so can be shared
amongst all processes.

We'll calculate N such that we'll try to have sampled at least 0.05% of
all records in the cache, with a maximum of 50 estimates. Testing shows
this should roughly keep us within a +/-5% error margin.

There's a race condition on writing the moving average back, but that
should be rare and not important.

If the cache is small enough so that the queries sample all the data,
we'll just write the exact value back to the cache and ignore previous
estimates.