### PR TITLE
Set the expiry multiplier to 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For more information on cache clusters see [Sharding the cache](#sharding-the-ca
 
 ### Cache expiry
 
-Solid Cache tracks writes to the cache. For every write it increments a counter by 1. Once the counter reaches 80% of the `expiry_batch_size` it adds a task to run on a background thread. That task will:
+Solid Cache tracks writes to the cache. For every write it increments a counter by 1. Once the counter reaches 50% of the `expiry_batch_size` it adds a task to run on a background thread. That task will:
 
 1. Check if we have exceeded the `max_entries` or `max_size` values (if set)
    The current entries are estimated by subtracting the max and min IDs from the `SolidCache::Entry` table.
@@ -149,7 +149,7 @@ Solid Cache tracks writes to the cache. For every write it increments a counter 
 2. If we have it will delete `expiry_batch_size` entries
 3. If not it will delete up to `expiry_batch_size` entries, provided they are all older than `max_age`.
 
-Expiring when we reach 80% of the batch size allows us to expire records from the cache faster than we write to it when we need to reduce the cache size.
+Expiring when we reach 50% of the batch size allows us to expire records from the cache faster than we write to it when we need to reduce the cache size.
 
 Only triggering expiry when we write means that the if the cache is idle, the background thread is also idle.
 

--- a/lib/solid_cache/cluster/expiry.rb
+++ b/lib/solid_cache/cluster/expiry.rb
@@ -7,7 +7,7 @@ module SolidCache
     module Expiry
       # For every write that we do, we attempt to delete EXPIRY_MULTIPLIER times as many records.
       # This ensures there is downward pressure on the cache size while there is valid data to delete
-      EXPIRY_MULTIPLIER = 1.25
+      EXPIRY_MULTIPLIER = 2
 
       attr_reader :expiry_batch_size, :expiry_method, :expiry_queue, :expires_per_write, :max_age, :max_entries, :max_size
 


### PR DESCRIPTION
This allows us to trim the cache more aggresively for when we want to reduce the cache size.