### PR TITLE
Require solid_cache in the store

### DIFF
--- a/lib/active_support/cache/solid_cache_store.rb
+++ b/lib/active_support/cache/solid_cache_store.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "solid_cache"
+
 module ActiveSupport
   module Cache
     SolidCacheStore = SolidCache::Store


### PR DESCRIPTION
In case we have `gem "solid_cache", require "false"` in our Gemfile.