### PR TITLE
Update migrations to be compatible with Rails >= 7

### DIFF
--- a/db/migrate/20240108155507_add_key_hash_and_byte_size_to_solid_cache_entries.rb
+++ b/db/migrate/20240108155507_add_key_hash_and_byte_size_to_solid_cache_entries.rb
@@ -1,4 +1,4 @@
-class AddKeyHashAndByteSizeToSolidCacheEntries < ActiveRecord::Migration[7.1]
+class AddKeyHashAndByteSizeToSolidCacheEntries < ActiveRecord::Migration[7.0]
   def change
     change_table :solid_cache_entries do |t|
       t.column :key_hash,  :integer, null: true, limit: 8

--- a/db/migrate/20240110111600_add_key_hash_and_byte_size_indexes_and_null_constraints_to_solid_cache_entries.rb
+++ b/db/migrate/20240110111600_add_key_hash_and_byte_size_indexes_and_null_constraints_to_solid_cache_entries.rb
@@ -1,4 +1,4 @@
-class AddKeyHashAndByteSizeIndexesAndNullConstraintsToSolidCacheEntries < ActiveRecord::Migration[7.1]
+class AddKeyHashAndByteSizeIndexesAndNullConstraintsToSolidCacheEntries < ActiveRecord::Migration[7.0]
   def change
     change_table :solid_cache_entries, bulk: true do |t|
       t.change_null :key_hash, false

--- a/db/migrate/20240110111702_remove_key_index_from_solid_cache_entries.rb
+++ b/db/migrate/20240110111702_remove_key_index_from_solid_cache_entries.rb
@@ -1,4 +1,4 @@
-class RemoveKeyIndexFromSolidCacheEntries < ActiveRecord::Migration[7.1]
+class RemoveKeyIndexFromSolidCacheEntries < ActiveRecord::Migration[7.0]
   def change
     change_table :solid_cache_entries do |t|
       t.remove_index :key, unique: true


### PR DESCRIPTION
This PR ensures that migrations won't fail when running in a Rails 7.0 application.