### PR TITLE
Disable the query cache without workarounds

### DIFF
--- a/lib/solid_cache/store/entries.rb
+++ b/lib/solid_cache/store/entries.rb
@@ -65,13 +65,13 @@ module SolidCache
 
         def entry_delete(key)
           writing_key(key, failsafe: :delete_entry, failsafe_returning: false) do
-            Entry.delete_by_key(key)
+            Entry.delete_by_key(key) > 0
           end
         end
 
         def entry_delete_multi(entries)
           writing_keys(entries, failsafe: :delete_multi_entries, failsafe_returning: 0) do
-            Entry.delete_multi(entries)
+            Entry.delete_by_key(*entries)
           end
         end
     end


### PR DESCRIPTION
Use the new `dirties: false` option to `uncached` to disable the query cache and avoid the messy workarounds.

Currently only available in Rails edge so this will need to wait for its release. Will be part of Solid Cache v1.0, which will drop support for Rails 7.1 and earlier.