### PR TITLE
Support unless_exist

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -52,7 +52,7 @@ module SolidCache
           uncached do
             result = lock.where(key_hash: key_hash_for(key)).pick(:key, :value)
             new_value = block.call(result&.first == key ? result[1] : nil)
-            write(key, new_value)
+            write(key, new_value) if new_value
             new_value
           end
         end

--- a/lib/solid_cache/store/entries.rb
+++ b/lib/solid_cache/store/entries.rb
@@ -29,7 +29,9 @@ module SolidCache
 
         def entry_lock_and_write(key, &block)
           writing_key(key, failsafe: :increment) do
-            Entry.lock_and_write(key, &block)
+            Entry.lock_and_write(key) do |value|
+              block.call(value).tap { |result| track_writes(1) if result }
+            end
           end
         end
 

--- a/test/unit/solid_cache_test.rb
+++ b/test/unit/solid_cache_test.rb
@@ -54,6 +54,17 @@ class SolidCacheTest < ActiveSupport::TestCase
     cache = lookup_store(max_age: 7200)
     assert_equal 7200, cache.max_age
   end
+
+  def test_write_with_unless_exist
+    assert_equal true, @cache.write("foo", 1)
+    assert_equal false, @cache.write("foo", 1, unless_exist: true)
+  end
+
+  def test_write_expired_value_with_unless_exist
+    assert_equal true, @cache.write(1, "aaaa", expires_in: 1.second)
+    travel 2.seconds
+    assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
+  end
 end
 
 class SolidCacheFailsafeTest < ActiveSupport::TestCase


### PR DESCRIPTION
Add support for the unless_exist option to the write method. This will not overwrite the value and return false if the key already exists in the cache and is not expired.

Fixes: https://github.com/rails/solid_cache/issues/183