### PR TITLE
Docs: Run full installation by default (not just migrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,35 @@ Or install it yourself as:
 $ gem install solid_cache
 ```
 
+Now, you need to install the necessary migrations and configure the cache store. You can do both at once using the provided generator:
+
+```bash
+$ bin/rails generate solid_cache:install
+```
+
+This will set solid_cache as the cache store in production, and will copy the optional configuration file and the required migration over to your app.
+
+Alternatively, you can add only the migration to your app:
+
+```bash
+$ bin/rails solid_cache:install:migrations
+```
+
+And set Solid Cache as your application's cache store backend manually, in your environment config:
+
+```ruby
+# config/environments/production.rb
+config.cache_store = :solid_cache_store
+```
+
 Add the migration to your app:
 
 ```bash
 $ bin/rails solid_cache:install
 ```
 
-Then run it:
+Finally, you need to run the migrations:
+
 ```bash
 $ bin/rails db:migrate
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ gem install solid_cache
 Add the migration to your app:
 
 ```bash
-$ bin/rails solid_cache:install:migrations
+$ bin/rails solid_cache:install
 ```
 
 Then run it:

--- a/README.md
+++ b/README.md
@@ -59,12 +59,6 @@ And set Solid Cache as your application's cache store backend manually, in your 
 config.cache_store = :solid_cache_store
 ```
 
-Add the migration to your app:
-
-```bash
-$ bin/rails solid_cache:install
-```
-
 Finally, you need to run the migrations:
 
 ```bash


### PR DESCRIPTION
The current README command only add the migrations, not the config files.

But, two lines later in the same file, the docs reference `Configuration will be read from config/solid_cache.yml` - but, that file doesn't exist according to the current installation instructions. 

~~I think this approach is cleaner, especially so that changes in `defaults` on version upgrades don't cause weird issues in the future~~.

**Update:** I refactored to match the docs style of the `solid_queue` docs, which defaults to the full installation by default but explains a more manual approach.