### PR TITLE
Correct config database

### DIFF
--- a/lib/generators/solid_cache/install/templates/config/solid_cache.yml.tt
+++ b/lib/generators/solid_cache/install/templates/config/solid_cache.yml.tt
@@ -1,5 +1,5 @@
 default: &default
-  database: <%%= Rails.env %>
+  database: <%= ENV.fetch("DATABASE", "cache") %>
   store_options:
     max_age: <%%= 1.week.to_i %>
     max_size: <%%= 256.megabytes %>

--- a/test/lib/generators/solid_cache/solid_cache/install_generator_test.rb
+++ b/test/lib/generators/solid_cache/solid_cache/install_generator_test.rb
@@ -29,7 +29,7 @@ module SolidCache
       def expected_config
         <<~YAML
           default: &default
-            database: <%= Rails.env %>
+            database: cache
             store_options:
               max_age: <%= 1.week.to_i %>
               max_size: <%= 256.megabytes %>


### PR DESCRIPTION
1. Use the DATABASE environment variable to match the name used in the installer
2. Default to "cache" which will match what Rails generators will use