### PR TITLE
Improve performance of reading cache entries

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -92,6 +92,17 @@ module SolidCache
           connection.supports_insert_conflict_target? ? :key_hash : nil
         end
 
+        # This constructs and caches a SQL query for a given number of keys.
+        #
+        # The query is constructed with two bind parameters to generate an IN (...) condition,
+        # which is then replaced with the correct amount based on the number of keys. The
+        # parameters are filled later when executing the query. This is done through Active Record
+        # to ensure the field and table names are properly quoted and escaped based on the used database adapter.
+
+        # For example: The query for 4 keys will be transformed from:
+        # > SELECT "key", "value" FROM "solid_cache_entries" WHERE "key_hash" IN (1111, 2222)
+        # into:
+        # > SELECT "key", "value" FROM "solid_cache_entries" WHERE "key_hash" IN (?, ?, ?, ?)
         def select_sql(keys)
           @select_sql ||= {}
           @select_sql[keys.count] ||= \

--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -40,7 +40,7 @@ module SolidCache
             find_by_sql(query).pluck(:key, :value).to_h
           else
             # If encryption is disabled, we can go straight to the database.
-            connection.select_rows(query).to_h
+            connection.select_all(query, "SolidCache::Entry Load").cast_values.to_h
           end
         end
       end

--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -33,7 +33,7 @@ module SolidCache
 
       def read_multi(keys)
         without_query_cache do
-          find_by_sql([select_sql(keys), *key_hashes_for(keys)]).pluck(:key, :value).to_h
+          connection.select_rows(select_sql(keys), "SQL", key_hashes_for(keys)).to_h
         end
       end
 

--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -35,13 +35,7 @@ module SolidCache
         without_query_cache do
           query = Arel.sql(select_sql(keys), *key_hashes_for(keys))
 
-          if SolidCache.configuration.encrypt?
-            # If encryption is enabled, we need to go through AR to decrypt the columns.
-            find_by_sql(query).pluck(:key, :value).to_h
-          else
-            # If encryption is disabled, we can go straight to the database.
-            connection.select_all(query, "SolidCache::Entry Load").cast_values.to_h
-          end
+          connection.select_all(query, "SolidCache::Entry Load").cast_values(attribute_types).to_h
         end
       end
 

--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -95,7 +95,10 @@ module SolidCache
         def select_sql(keys)
           @select_sql ||= {}
           @select_sql[keys.count] ||= \
-            "SELECT key, value FROM #{table_name} WHERE key_hash IN (#{Array.new(keys.count, "?").join(", ")})"
+            where(key_hash: [ 1111, 2222 ])
+              .select(:key, :value)
+              .to_sql
+              .gsub("1111, 2222", Array.new(keys.count, "?").join(", "))
         end
 
         def key_hash_for(key)

--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -85,12 +85,9 @@ module SolidCache
         end
 
         def select_sql(keys)
-          @get_sql ||= {}
-          @get_sql[keys.count] ||= \
-            where(key_hash: [ "1111", "2222" ])
-              .select(:key, :value)
-              .to_sql
-              .gsub("1111, 2222", (["?"] * keys.count).join(", "))
+          @select_sql ||= {}
+          @select_sql[keys.count] ||= \
+            "SELECT key, value FROM #{table_name} WHERE key_hash IN (#{Array.new(keys.count, "?").join(", ")})"
         end
 
         def key_hash_for(key)


### PR DESCRIPTION
I saw the release of 1.0.0 and noticed the code for reading queries from the database.

I found it a curious approach (took a while to figure out what the `gsub` did) and decide to have a try at making it more readable and in the end I also had some fun benchmarking the query and made it about 50% faster!

---

Here's my benchmark script:

```rb
require 'benchmark/ips'

require_relative "./test/test_helper"

Benchmark.ips do |x|
  x.report("Entry.read") { SolidCache::Entry.read('bla') }
  x.report("Entry.read_multi") { SolidCache::Entry.read_multi(['bla', 'blabla']) }
end
```

And here are some of my results, ran on a 2021 MBP M1 Pro.

With SQLite:

| What | Entry.read (i/s) | % | Entry.read_multi (i/s) | % |
| ---- | ---------------- | - | ---------------------- | - |
| **Current implementation** | **15.682k (± 2.8%)** | - | **14.543k (± 4.8%)** | - |
| With direct AR query (1) | 9.958k (± 3.0%) | -36.5% | 8.910k (± 3.7%) | -38.7% |
| With encrypted column (2) | 16.871k (± 3.1%) | +7,6% | 14.972k (± 5.6%) | +2,94% |
| With regular column (3) | 19.740k (± 4.9%) | +25,9% | 18.320k (± 7.2%) | +26,0% |

With Postgres (running from the Docker container) there's a even bigger performance gain, although the variability is also very high and the overal numbers are way lower, so not sure how reliable the numbers are. They are consistently higher when running the benchmark multiple times, though.

| What | Entry.read (i/s) | % | Entry.read_multi (i/s) | % |
| ---- | ---------------- | - | ---------------------- | - |
| **Current implementation** | **1.029k (±24.1%)** | - | **1.025k (±23.0%)** | - |
| With regular column (3) | 1.818k (±42.6%) | +76,7% | 1.921k (±33.3%) | +87,4% |

(1) I decided to see how it would perform with a plain and simple Active Record query, also as a reference:

```rb
def read_multi(keys)
  without_query_cache do
    where(key_hash: key_hashes_for(keys)).pluck(:key, :value).to_h
  end
end
```

(2) with encrypted columns it uses the current implementation, so that performance will be similar to the current.

(3) is the code as in this PR.

The main performance gain is gained by querying directly and not instantiating any `SolidCache::Entry` objects when the data is not encrypted.

---

Curious to hear your thoughts, happy to make improvements in any direction.