### PR TITLE
Support binary encryption on PostgreSQL for Rails 8

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ end
 configs.each do |config|
   namespace :test do
     task config do
-      if config.to_s.start_with?("encrypted") && ENV["TARGET_DB"] == "postgres"
+      if config.to_s.start_with?("encrypted") && ENV["TARGET_DB"] == "postgres" && Rails::VERSION::MAJOR <= 7
         puts "Skipping encrypted tests on PostgreSQL as binary encrypted columns are not supported by Rails yet"
         next
       end

--- a/lib/solid_cache/engine.rb
+++ b/lib/solid_cache/engine.rb
@@ -37,9 +37,9 @@ module SolidCache
     end
 
     config.after_initialize do
-      if SolidCache.configuration.encrypt? && SolidCache::Record.connection.adapter_name == "PostgreSQL"
+      if SolidCache.configuration.encrypt? && Record.connection.adapter_name == "PostgreSQL" && Rails::VERSION::MAJOR <= 7
         raise \
-          "Cannot enable encryption for Solid Cache: Active Record Encryption does not currently support " \
+          "Cannot enable encryption for Solid Cache: in Rails 7, Active Record Encryption does not support " \
           "encrypting binary columns on PostgreSQL"
       end
     end


### PR DESCRIPTION
Support was added in https://github.com/rails/rails/pull/52729, so we can remove the check for Rails 8.