### PR TITLE
Remove warning about encryption on PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,6 @@ config.solid_cache.encryption_context_properties = {
 }
 ```
 
-**Note**
-
-Encryption currently does not work for PostgreSQL, as Rails does not yet support encrypting binary columns for it.
-See https://github.com/rails/rails/pull/52650.
-
 ## Index size limits
 The Solid Cache migrations try to create an index with 1024 byte entries. If that is too big for your database, you should:
 


### PR DESCRIPTION
The `README` contained a warning about encryption on PostgreSQL, but this has now been fixed and merged in  https://github.com/rails/rails/pull/52650

This PR removes the note from the `README`.