### PR TITLE
Require active_record in engine.rb

### DIFF
--- a/lib/solid_cache/engine.rb
+++ b/lib/solid_cache/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_record"
 
 module SolidCache
   class Engine < ::Rails::Engine


### PR DESCRIPTION
Ensure we load active_record before solid_cache - cc @dhh 