### PR TITLE
Adds fallback to app_name_from_production_database_name

### DIFF
--- a/lib/generators/solid_cache/install/install_generator.rb
+++ b/lib/generators/solid_cache/install/install_generator.rb
@@ -51,7 +51,7 @@ class SolidCache::InstallGenerator < Rails::Generators::Base
     end
 
     def app_name_from_production_database_name
-      database_yml.read.scan(/database: (\w+)_production/).flatten.first || "app"
+      database_yml.read.scan(/database: (\w+)_production/).flatten.first || (defined?(Rails) ? Rails.application.name.underscore : "app")
     end
 
     def generic_database_config_with_cache

--- a/lib/generators/solid_cache/install/install_generator.rb
+++ b/lib/generators/solid_cache/install/install_generator.rb
@@ -51,7 +51,7 @@ class SolidCache::InstallGenerator < Rails::Generators::Base
     end
 
     def app_name_from_production_database_name
-      database_yml.read.scan(/database: (\w+)_production/).flatten.first
+      database_yml.read.scan(/database: (\w+)_production/).flatten.first || "app"
     end
 
     def generic_database_config_with_cache


### PR DESCRIPTION
`app_name_from_production_database_name` can sometimes return `nil` if your config does not match the expected format.

This pull request adds a default to this method so the generator does not fail when calling `app_name.upcase`.