### PR TITLE
Filter expiry candidates in database

### DIFF
--- a/app/models/solid_cache/entry/expiration.rb
+++ b/app/models/solid_cache/entry/expiration.rb
@@ -39,9 +39,7 @@ module SolidCache
               candidate_ids = if cache_full
                 candidates.pluck(:id)
               else
-                min_created_at = max_age.seconds.ago
-                candidates.pluck(:id, :created_at)
-                          .filter_map { |id, created_at| id if created_at < min_created_at }
+                candidates.where("created_at < ?", max_age.seconds.ago).pluck(:id)
               end
 
               candidate_ids.sample(count)


### PR DESCRIPTION
Small improvement to filter out candidates by max age in the database, instead of in Ruby.

I'm not entirely sure why this was done this way before, but it seems to pass the tests. 