### PR TITLE
Always manage connections when database is specified

### DIFF
--- a/lib/solid_cache/configuration.rb
+++ b/lib/solid_cache/configuration.rb
@@ -35,7 +35,7 @@ module SolidCache
         @connects_to =
           case
           when database
-            { database: { writing: database.to_sym } }
+            { shards: { database.to_sym => { writing: database.to_sym } } }
           when databases
             { shards: databases.map(&:to_sym).index_with { |database| { writing: database } } }
           when connects_to

--- a/test/models/solid_cache/record_test.rb
+++ b/test/models/solid_cache/record_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 module SolidCache
   class RecordTest < ActiveSupport::TestCase
-    SINGLE_DB_CONFIGS = [ "config/solid_cache_no_database.yml", "config/solid_cache_database.yml", "config/solid_cache_unprepared_statements.yml" ]
+    SINGLE_DB_CONFIGS = [ "config/solid_cache_database.yml", "config/solid_cache_unprepared_statements.yml" ]
     MULTI_DB_CONFIGS = [
       "config/solid_cache_connects_to.yml",
       "config/solid_cache_encrypted.yml",
@@ -16,8 +16,12 @@ module SolidCache
     test "each_shard" do
       shards = SolidCache::Record.each_shard.map { SolidCache::Record.current_shard }
       case ENV["SOLID_CACHE_CONFIG"]
-      when *SINGLE_DB_CONFIGS
+      when "config/solid_cache_no_database.yml"
         assert_equal [ :default ], shards
+      when "config/solid_cache_database.yml"
+        assert_equal [ :primary ], shards
+      when "config/solid_cache_unprepared_statements.yml"
+        assert_equal [ :primary_unprepared_statements ], shards
       when *MULTI_DB_CONFIGS
         assert_equal [ :primary_shard_one, :primary_shard_two, :secondary_shard_one, :secondary_shard_two ], shards
       else
@@ -28,8 +32,10 @@ module SolidCache
     test "each_shard uses the default role" do
       role = ActiveRecord::Base.connected_to(role: :reading) { SolidCache::Record.each_shard.map { SolidCache::Record.current_role } }
       case ENV["SOLID_CACHE_CONFIG"]
-      when *SINGLE_DB_CONFIGS
+      when "config/solid_cache_no_database.yml"
         assert_equal [ :reading ], role
+      when *SINGLE_DB_CONFIGS
+        assert_equal [ :writing ], role
       when *MULTI_DB_CONFIGS
         assert_equal [ :writing, :writing, :writing, :writing ], role
       else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,7 +74,7 @@ class ActiveSupport::TestCase
   end
 
   def first_shard_key
-    single_database? ? :default : SolidCache.configuration.shard_keys.first
+    default_database? ? :default : SolidCache.configuration.shard_keys.first
   end
 
   def second_shard_key
@@ -83,6 +83,10 @@ class ActiveSupport::TestCase
 
   def single_database?
     [ "config/solid_cache_database.yml", "config/solid_cache_no_database.yml", "config/solid_cache_unprepared_statements.yml" ].include?(ENV["SOLID_CACHE_CONFIG"])
+  end
+
+  def default_database?
+    ENV["SOLID_CACHE_CONFIG"] == "config/solid_cache_no_database.yml"
   end
 
   def shard_keys(cache, shard)

--- a/test/unit/expiry_test.rb
+++ b/test/unit/expiry_test.rb
@@ -9,7 +9,7 @@ class SolidCache::ExpiryTest < ActiveSupport::TestCase
 
   setup do
     @namespace = "test-#{SecureRandom.hex}"
-    @single_shard_cluster = single_database? ? {} : { shards: [ first_shard_key ] }
+    @single_shard_cluster = default_database? ? {} : { shards: [ first_shard_key ] }
   end
 
   teardown do


### PR DESCRIPTION
When a database is specified, we should always manage connections so that we can ensure the cache is writable.

But if you just use the default connection for the rest of the app, we won't attempt to manage that.

Fixes: https://github.com/rails/solid_cache/issues/214