### PR TITLE
Remove unused require

### DIFF
--- a/lib/solid_cache/store/expiry.rb
+++ b/lib/solid_cache/store/expiry.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "concurrent/atomic/atomic_fixnum"
-
 module SolidCache
   class Store
     module Expiry


### PR DESCRIPTION
`concurrent/atomic/atomic_fixnum` was added by 2708b78a945eeb8874b1a57bf36c6f66320ee2bc. But, `Concurrent::AtomicFixnum` removed by b7b14b7.