### PR TITLE
Update README with Manual Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ production: &production
 
 For the full list of keys for `store_options` see [Cache configuration](#cache-configuration). Any options passed to the cache lookup will overwrite those specified here.
 
+After running `solid_cache:install`, `environments/production.rb` will replace your cache store with Solid Cache, but you can also do this manually:
+
+```ruby
+# config/environments/production.rb
+config.cache_store = :solid_cache_store
+```
+
 ### Connection configuration
 
 You can set one of `database`, `databases` and `connects_to` in the config file. They will be used to configure the cache databases in `SolidCache::Record#connects_to`.


### PR DESCRIPTION
Today the install_generator performs a gsub if there's an existing cache_store set, but if there isn't it does nothing.  It wasn't obvious that `cache_store` should be set to `solid_cache_store` so adding manual instructions for those upgrading or using cache for the first time.