### PR TITLE
Clean up tests, made some public methods in Connections module private

### DIFF
--- a/test/unit/behaviors/cache_increment_decrement_behavior.rb
+++ b/test/unit/behaviors/cache_increment_decrement_behavior.rb
@@ -31,14 +31,14 @@ module CacheIncrementDecrementBehavior
     assert_equal -100, missing
   end
 
-  def test_ttl_isnt_updated
+  def test_ttl_is_not_updated
     key = SecureRandom.uuid
 
     assert_equal 1, @cache.increment(key, 1, expires_in: 1)
     assert_equal 2, @cache.increment(key, 1, expires_in: 5000)
 
-    # having to sleep two seconds in a test is bad, but we're testing
-    # a wide range of backends with different TTL mecanisms, most without
+    # Having to sleep two seconds in a test is bad, but we're testing
+    # a wide range of backends with different TTL mechanisms, most without
     # subsecond granularity, so this is the only reliable way.
     sleep 2
 

--- a/test/unit/behaviors_rails_7_2/cache_increment_decrement_behavior.rb
+++ b/test/unit/behaviors_rails_7_2/cache_increment_decrement_behavior.rb
@@ -31,14 +31,14 @@ module CacheIncrementDecrementBehavior
     assert_equal -100, missing
   end
 
-  def test_ttl_isnt_updated
+  def test_ttl_is_not_updated
     key = SecureRandom.uuid
 
     assert_equal 1, @cache.increment(key, 1, expires_in: 1)
     assert_equal 2, @cache.increment(key, 1, expires_in: 5000)
 
-    # having to sleep two seconds in a test is bad, but we're testing
-    # a wide range of backends with different TTL mecanisms, most without
+    # Having to sleep two seconds in a test is bad, but we're testing
+    # a wide range of backends with different TTL mechanisms, most without
     # subsecond granularity, so this is the only reliable way.
     sleep 2
 

--- a/test/unit/delete_matched_test.rb
+++ b/test/unit/delete_matched_test.rb
@@ -14,7 +14,7 @@ class DeleteMatchedTest < ActiveSupport::TestCase
     @peek = lookup_store(expires_in: 60)
   end
 
-  test "deletes matched raises a NotImplementedError" do
+  test "delete matched raises a NotImplementedError" do
     prefix = SecureRandom.alphanumeric
     assert_raises(NotImplementedError) { @cache.delete_matched("#{prefix}%") }
   end

--- a/test/unit/execution_test.rb
+++ b/test/unit/execution_test.rb
@@ -75,7 +75,7 @@ class SolidCache::ExecutionTest < ActiveSupport::TestCase
     }
 
     ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
-      # Warm up the connections as they may log before instrumenation can be disabled
+      # Warm up the connections as they may log before instrumentation can be disabled
       uninstrumented_cache.write("foo", "bar")
       uninstrumented_cache.write("foo", "bar")
       uninstrumented_cache.write("foo", "bar")
@@ -90,7 +90,7 @@ class SolidCache::ExecutionTest < ActiveSupport::TestCase
     end
 
     ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
-      # Warm up the connections as they may log before instrumenation can be disabled
+      # Warm up the connections as they may log before instrumentation can be disabled
       instrumented_cache.write("foo", "bar")
       instrumented_cache.write("foo", "bar")
       instrumented_cache.write("foo", "bar")


### PR DESCRIPTION
- Cleaned up typos in `/test/...`
- Made some public methods in `lib/solid_cache/store/connections.rb` private.
- Renamed the inner `entries` to `grouped_entries` and `grouped_keys` in `lib/solid_cache/store/connections.rb`.