### PR TITLE
Avoid reloading the app directory

### DIFF
--- a/lib/solid_cache.rb
+++ b/lib/solid_cache.rb
@@ -6,6 +6,7 @@ require "solid_cache/engine"
 loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/active_support")
 loader.ignore("#{__dir__}/generators")
+loader.ignore("#{__dir__}/../app")
 loader.setup
 
 module SolidCache


### PR DESCRIPTION
It's not currently safe to reload connection classes in Rails as the old class is cached in the pool config.

See: https://github.com/rails/rails/issues/54343

This can lead to issues like:
https://github.com/rails/solid_cache/issues/238