### PR TITLE
Don't failsafe ActiveRecord::ConnectionTimeoutError

### DIFF
--- a/lib/solid_cache/store/failsafe.rb
+++ b/lib/solid_cache/store/failsafe.rb
@@ -6,7 +6,6 @@ module SolidCache
       TRANSIENT_ACTIVE_RECORD_ERRORS = [
         ActiveRecord::AdapterTimeout,
         ActiveRecord::ConnectionNotEstablished,
-        ActiveRecord::ConnectionTimeoutError,
         ActiveRecord::Deadlocked,
         ActiveRecord::LockWaitTimeout,
         ActiveRecord::QueryCanceled,


### PR DESCRIPTION
It hides the error and you end up with a different error anyway as the connection is nil.

Fixes: https://github.com/rails/solid_cache/issues/235