### PR TITLE
Default the logger to the Rails logger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-22
   x86_64-linux

--- a/lib/solid_cache.rb
+++ b/lib/solid_cache.rb
@@ -11,6 +11,8 @@ loader.setup
 module SolidCache
   mattr_accessor :executor
   mattr_accessor :configuration, default: Configuration.new
+
+  ActiveSupport.run_load_hooks(:solid_cache, self)
 end
 
 loader.eager_load

--- a/lib/solid_cache/engine.rb
+++ b/lib/solid_cache/engine.rb
@@ -36,8 +36,16 @@ module SolidCache
       SolidCache.executor = config.solid_cache.executor || app.executor
     end
 
-    config.after_initialize do
-      Rails.cache.setup! if Rails.cache.is_a?(Store)
+    initializer "solid_cache.logger" do
+      ActiveSupport.on_load(:solid_cache) do
+        Store.logger ||= Rails.logger
+      end
+    end
+
+    initializer "solid_cache.setup" do
+      ActiveSupport.on_load(:solid_cache) do
+        Rails.cache.setup! if Rails.cache.is_a?(Store)
+      end
     end
 
     config.after_initialize do

--- a/test/unit/solid_cache_test.rb
+++ b/test/unit/solid_cache_test.rb
@@ -65,6 +65,10 @@ class SolidCacheTest < ActiveSupport::TestCase
     travel 2.seconds
     assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
   end
+
+  test "store logger defaults to Rails logger" do
+    assert_equal Rails.logger, @cache.logger
+  end
 end
 
 class SolidCacheFailsafeTest < ActiveSupport::TestCase


### PR DESCRIPTION
Ensure errors are logged to the Rails logger by default.

Also re-use the new load hook to call setup! on the cache store.