### PR TITLE
Remove `frozen_string_literal` from schema.rb

### DIFF
--- a/lib/generators/solid_cache/install/templates/db/cache_schema.rb
+++ b/lib/generators/solid_cache/install/templates/db/cache_schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ActiveRecord::Schema[7.2].define(version: 1) do
   create_table "solid_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false


### PR DESCRIPTION
This makes it consistent with https://github.com/rails/solid_queue/blob/main/lib/generators/solid_queue/install/templates/db/queue_schema.rb and https://github.com/rails/solid_cable/blob/main/lib/generators/solid_cable/install/templates/db/cable_schema.rb