### PR TITLE
docs: update readme yaml config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ production: &production
   databases: [production_cache1, production_cache2]
   store_options:
     <<: *default_store_options
-    max_entries: <%= 256.gigabytes %>
+    max_entries: 10_000_000 # default is null
 ```
 
 For the full list of keys for `store_options` see [Cache configuration](#cache-configuration). Any options passed to the cache lookup will overwrite those specified here.


### PR DESCRIPTION
This very minor change updates a mistake I noticed in the readme for the yaml config of solid cache for `max_entries`