### PR TITLE
Document single database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ production:
 
 Then run `db:prepare` in production to ensure the database is created and the schema is loaded.
 
+### Single database configuration
+
+Running Solid Cache in a separate database is recommended, but it's also possible to use one single database for both the app and the queue. Follow these steps:
+
+1. Copy the contents of `db/cache_schema.rb` into a normal migration and delete `db/cache_schema.rb`
+2. Remove `database: cache` from `cache.yml`
+3. Migrate your database.
+
+You won't have multiple databases, so `database.yml` doesn't need to have primary and cache database.
+
 ## Configuration
 
 Configuration will be read from `config/cache.yml` or `config/solid_cache.yml`. You can change the location of the config file by setting the `SOLID_CACHE_CONFIG` env variable.


### PR DESCRIPTION
Creates parity with documentation for [Solid Cable][1] and [Solid Queue][2].

[1]: https://github.com/rails/solid_cable?tab=readme-ov-file#single-database-configuration
[2]: https://github.com/rails/solid_queue?tab=readme-ov-file#single-database-configuration