### PR TITLE
Allow a single database in databases configuration

### DIFF
--- a/lib/solid_cache/configuration.rb
+++ b/lib/solid_cache/configuration.rb
@@ -37,7 +37,7 @@ module SolidCache
           when database
             { shards: { database.to_sym => { writing: database.to_sym } } }
           when databases
-            { shards: databases.map(&:to_sym).index_with { |database| { writing: database } } }
+            { shards: Array(databases).map(&:to_sym).index_with { |database| { writing: database } } }
           when connects_to
             connects_to
           else

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SolidCache::ConfigurationTest < ActiveSupport::TestCase
+  test "databases option accepts a single database name as a string" do
+    config = SolidCache::Configuration.new(databases: "cache")
+    assert_equal({ shards: { cache: { writing: :cache } } }, config.connects_to)
+  end
+
+  test "databases option accepts a single database name as a symbol" do
+    config = SolidCache::Configuration.new(databases: :cache)
+    assert_equal({ shards: { cache: { writing: :cache } } }, config.connects_to)
+  end
+
+  test "databases option accepts an array of database names" do
+    config = SolidCache::Configuration.new(databases: [:cache1, :cache2])
+    assert_equal({
+      shards: {
+        cache1: { writing: :cache1 },
+        cache2: { writing: :cache2 }
+      }
+    }, config.connects_to)
+  end
+
+  test "database option accepts a single database name" do
+    config = SolidCache::Configuration.new(database: :cache)
+    assert_equal({ shards: { cache: { writing: :cache } } }, config.connects_to)
+  end
+
+  test "raises ArgumentError when multiple connection options are provided" do
+    error = assert_raises(ArgumentError) do
+      SolidCache::Configuration.new(database: :cache, databases: [:cache1])
+    end
+    assert_equal "You can only specify one of :database, :databases, or :connects_to", error.message
+  end
+end


### PR DESCRIPTION
No need to be strict about this, we know what the user means.

Fixes: https://github.com/rails/solid_cache/issues/267