### PR TITLE
Loosen up rules about `database` vs `databases` naming config

### DIFF
--- a/lib/solid_cache/configuration.rb
+++ b/lib/solid_cache/configuration.rb
@@ -34,10 +34,8 @@ module SolidCache
 
         @connects_to =
           case
-          when database
-            { shards: { database.to_sym => { writing: database.to_sym } } }
-          when databases
-            { shards: Array(databases).map(&:to_sym).index_with { |database| { writing: database } } }
+          when (dbs = database || databases)
+            { shards: Array(dbs).map(&:to_sym).index_with { |db| { writing: db } } }
           when connects_to
             connects_to
           else

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -28,6 +28,27 @@ class SolidCache::ConfigurationTest < ActiveSupport::TestCase
     assert_equal({ shards: { cache: { writing: :cache } } }, config.connects_to)
   end
 
+  test "database option also accepts an array of database names" do
+    config = SolidCache::Configuration.new(database: [:cache1, :cache2])
+    assert_equal({
+      shards: {
+        cache1: { writing: :cache1 },
+        cache2: { writing: :cache2 }
+      }
+    }, config.connects_to)
+  end
+
+  test "should respect connects_to option" do
+    connects_to = {
+      shards: {
+        cache1: { writing: :cache1 },
+        cache2: { writing: :cache2 }
+      }
+    }
+    config = SolidCache::Configuration.new(connects_to: connects_to)
+    assert_equal(connects_to, config.connects_to)
+  end
+
   test "raises ArgumentError when multiple connection options are provided" do
     error = assert_raises(ArgumentError) do
       SolidCache::Configuration.new(database: :cache, databases: [:cache1])


### PR DESCRIPTION
Follow up of https://github.com/rails/solid_cache/pull/286

I guess it also makes sense to handle the opposite case