### PR TITLE
Fix lock_and_write races for missing cache entries

### DIFF
--- a/app/models/solid_cache/entry.rb
+++ b/app/models/solid_cache/entry.rb
@@ -67,12 +67,21 @@ module SolidCache
         end
       end
 
-      def lock_and_write(key, &block)
+      def lock_and_write(key, placeholder_payload: nil, &block)
         transaction do
           without_query_cache do
+            ensure_lockable_row_exists(key, placeholder_payload) if placeholder_payload
+
             result = lock.where(key_hash: key_hash_for(key)).pick(:key, :value)
-            new_value = block.call(result&.first == key ? result[1] : nil)
-            write(key, new_value) if new_value
+            current_value = result&.first == key ? result[1] : nil
+            new_value = block.call(current_value)
+
+            if new_value
+              write(key, new_value)
+            elsif placeholder_payload && current_value == placeholder_payload
+              delete_by_key(key)
+            end
+
             new_value
           end
         end
@@ -85,6 +94,31 @@ module SolidCache
       end
 
       private
+        def ensure_lockable_row_exists(key, payload)
+          retries = 0
+
+          begin
+            insert_all(
+              add_key_hash_and_byte_size([
+                { key: key, value: payload, created_at: Time.current }
+              ]),
+              unique_by: upsert_unique_by
+            )
+          rescue ActiveRecord::RecordNotUnique
+            # Another concurrent writer created the row first.
+          rescue ActiveRecord::StatementInvalid => error
+            raise unless sqlite_busy_exception?(error) && retries < 3
+
+            retries += 1
+            sleep(0.01 * retries)
+            retry
+          end
+        end
+
+        def sqlite_busy_exception?(error)
+          connection.adapter_name == "SQLite" && error.message.include?("database is locked")
+        end
+
         def add_key_hash_and_byte_size(payloads)
           payloads.map do |payload|
             payload.dup.tap do |payload|

--- a/lib/solid_cache/store/api.rb
+++ b/lib/solid_cache/store/api.rb
@@ -54,7 +54,10 @@ module SolidCache
 
           if unless_exist
             written = false
-            entry_lock_and_write(key) do |value|
+            entry_lock_and_write(
+              key,
+              placeholder_payload: expired_placeholder_payload(raw: raw, **options)
+            ) do |value|
               if value.nil? || deserialize_entry(value, **options).expired?
                 written = true
                 payload
@@ -155,7 +158,10 @@ module SolidCache
           options = merged_options(options)
           key = normalize_key(name, options)
 
-          new_value = entry_lock_and_write(key) do |value|
+          new_value = entry_lock_and_write(
+            key,
+            placeholder_payload: expired_placeholder_payload(**options)
+          ) do |value|
             serialize_entry(adjusted_entry(value, amount, options))
           end
           deserialize_entry(new_value, **options).value if new_value
@@ -173,6 +179,14 @@ module SolidCache
           else
             ActiveSupport::Cache::Entry.new(amount, **options)
           end
+        end
+
+        def expired_placeholder_payload(raw: false, **options)
+          serialize_entry(
+            ActiveSupport::Cache::Entry.new(nil, expires_in: -1),
+            raw: raw,
+            **options
+          )
         end
     end
   end

--- a/lib/solid_cache/store/entries.rb
+++ b/lib/solid_cache/store/entries.rb
@@ -27,9 +27,9 @@ module SolidCache
           end
         end
 
-        def entry_lock_and_write(key, &block)
+        def entry_lock_and_write(key, placeholder_payload: nil, &block)
           writing_key(key, failsafe: :increment) do
-            Entry.lock_and_write(key) do |value|
+            Entry.lock_and_write(key, placeholder_payload: placeholder_payload) do |value|
               block.call(value).tap { |result| track_writes(1) if result }
             end
           end

--- a/test/unit/solid_cache_test.rb
+++ b/test/unit/solid_cache_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "concurrent"
 require_relative "behaviors"
 require "active_support/testing/method_call_assertions"
 
@@ -64,6 +65,85 @@ class SolidCacheTest < ActiveSupport::TestCase
     assert_equal true, @cache.write(1, "aaaa", expires_in: 1.second)
     travel 2.seconds
     assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
+  end
+
+  def test_expired_placeholder_payload_deserializes_as_expired_entry
+    payload = @cache.send(
+      :serialize_entry,
+      ActiveSupport::Cache::Entry.new(nil, expires_in: -1)
+    )
+
+    entry = @cache.send(:deserialize_entry, payload)
+
+    assert entry
+    assert_predicate entry, :expired?
+  end
+
+  def test_concurrent_increment_on_missing_key_serializes_initial_creation
+    key = SecureRandom.uuid
+    barrier = Concurrent::CyclicBarrier.new(2)
+    results = Queue.new
+    errors = Queue.new
+
+    threads = 2.times.map do
+      Thread.new do
+        cache = lookup_store(namespace: @namespace, expires_in: 60)
+
+        barrier.wait
+        results << cache.increment(key)
+      rescue => error
+        errors << error
+      end
+    end
+
+    threads.each(&:join)
+
+    thread_errors = []
+    thread_errors << errors.pop until errors.empty?
+
+    assert_predicate thread_errors, :empty?, <<~MSG
+      expected no thread errors, got #{thread_errors.size}:
+      #{thread_errors.map { |e| "#{e.class}: #{e.message}\n#{Array(e.backtrace).first(10).join("\n")}" }.join("\n\n")}
+    MSG
+
+    values = 2.times.map { results.pop }.sort
+    assert_equal [1, 2], values
+    assert_equal 2, @cache.read(key, raw: true).to_i
+  end
+
+  def test_concurrent_write_with_unless_exist_only_writes_once_for_missing_key
+    key = SecureRandom.uuid
+    barrier = Concurrent::CyclicBarrier.new(2)
+    results = Queue.new
+    errors = Queue.new
+
+    payloads = [ "first", "second" ]
+
+    threads = payloads.map do |payload|
+      Thread.new(payload) do |value|
+        cache = lookup_store(namespace: @namespace, expires_in: 60)
+
+        barrier.wait
+        results << cache.write(key, value, unless_exist: true)
+      rescue => error
+        errors << error
+      end
+    end
+
+    threads.each(&:join)
+
+    thread_errors = []
+    thread_errors << errors.pop until errors.empty?
+
+    assert_predicate thread_errors, :empty?, <<~MSG
+      expected no thread errors, got #{thread_errors.size}:
+      #{thread_errors.map { |e| "#{e.class}: #{e.message}\n#{Array(e.backtrace).first(10).join("\n")}" }.join("\n\n")}
+    MSG
+
+    values = 2.times.map { results.pop }
+    assert_equal 1, values.count(true)
+    assert_equal 1, values.count(false)
+    assert_includes [ "first", "second" ], @cache.read(key)
   end
 end
 


### PR DESCRIPTION
### Summary

Fix a race in `lock_and_write` when the target cache entry does not exist yet.

This was first observed via `increment` / `decrement`, where concurrent calls against a missing key could both behave as if they were the first writer. The root cause is more general, though: `lock_and_write` only serializes updates once a backing row already exists.

This change makes `lock_and_write` create a lockable expired placeholder row before taking the lock, so the read-modify-write path is serialized even for missing entries.

### Motivation / Background

Rails' cache store API does not appear to require a single missing-key behavior for all stores, but the major counter-capable stores do support initializing a missing counter on first increment.

For example, both `RedisCacheStore` and `MemCacheStore` document that if a key is unset or expired, `increment` sets it to `amount`. That makes it reasonable for Solid Cache to preserve the same counter semantics under concurrency as well. ([api.rubyonrails.org](https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html))

While investigating that behavior, it turned out the underlying issue was not specific to counters: `lock_and_write` could not truly serialize access for missing entries because there was no row to lock yet.

### What changed

- extend `Entry.lock_and_write` to accept an optional `placeholder_payload:`
- create an expired serialized cache entry as a placeholder before locking a missing row
- use that placeholder path from:
  - `adjust` (`increment` / `decrement`)
  - `write_entry(..., unless_exist: true)`
- clean up an unused placeholder row if the caller decides not to write anything
- retry transient SQLite `database is locked` errors while creating the placeholder row

### Why an expired serialized entry?

The placeholder needs to satisfy the table constraints while still behaving like "no usable cache entry".

Using an expired serialized `ActiveSupport::Cache::Entry` lets the existing deserialization and expiration paths continue to work naturally, instead of introducing a separate sentinel format.

### Tests

Adds coverage for:

- expired placeholder payload deserializing as an expired entry
- concurrent `increment` on a missing key
- concurrent `write(..., unless_exist: true)` on a missing key

### Notes

I did see some flaky failures while iterating in CI, especially in SQLite-related matrices and in existing size-estimation tests. At least some of those appear to predate this change, so I tried to keep the implementation conservative and scoped to the missing-row locking problem itself.
