### PR TITLE
Catch ActiveRecord::ConnectionFailed in the failsafe

### DIFF
--- a/lib/solid_cache/store/failsafe.rb
+++ b/lib/solid_cache/store/failsafe.rb
@@ -5,6 +5,7 @@ module SolidCache
     module Failsafe
       TRANSIENT_ACTIVE_RECORD_ERRORS = [
         ActiveRecord::AdapterTimeout,
+        ActiveRecord::ConnectionFailed,
         ActiveRecord::ConnectionNotEstablished,
         ActiveRecord::Deadlocked,
         ActiveRecord::LockWaitTimeout,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,12 +95,20 @@ class ActiveSupport::TestCase
     shard_keys.map { |key| key.delete_prefix("#{@namespace}:") }
   end
 
-  def emulating_timeouts
+  def emulating_errors(error_class)
     ar_methods = [ :select_all, :delete, :exec_insert_all ]
     stub_matcher = ActiveRecord::Base.connection.class.any_instance
-    ar_methods.each { |method| stub_matcher.stubs(method).raises(ActiveRecord::StatementTimeout) }
+    ar_methods.each { |method| stub_matcher.stubs(method).raises(error_class) }
     yield
   ensure
     ar_methods.each { |method| stub_matcher.unstub(method) }
+  end
+
+  def emulating_timeouts(&block)
+    emulating_errors(ActiveRecord::StatementTimeout, &block)
+  end
+
+  def emulating_connection_failures(&block)
+    emulating_errors(ActiveRecord::ConnectionFailed, &block)
   end
 end

--- a/test/unit/solid_cache_test.rb
+++ b/test/unit/solid_cache_test.rb
@@ -89,6 +89,32 @@ class SolidCacheFailsafeTest < ActiveSupport::TestCase
   end
 end
 
+class SolidCacheConnectionFailedFailsafeTest < ActiveSupport::TestCase
+  include FailureSafetyBehavior
+
+  setup do
+    @cache = nil
+    @namespace = "test-#{SecureRandom.hex}"
+
+    @cache = lookup_store(expires_in: 60)
+    # @cache.logger = Logger.new($stdout)  # For test debugging
+
+    # For LocalCacheBehavior tests
+    @peek = lookup_store(expires_in: 60)
+  end
+
+  # A terminated connection raises ActiveRecord::ConnectionFailed, which is a
+  # subclass of ActiveRecord::StatementInvalid rather than of
+  # ActiveRecord::ConnectionNotEstablished, so it needs its own failsafe entry.
+  # Regression test for https://github.com/rails/solid_cache/issues/307.
+  def emulating_unavailability
+    wait_for_background_tasks(@cache)
+    emulating_connection_failures do
+      yield lookup_store(namespace: @namespace)
+    end
+  end
+end
+
 class SolidCacheRaisingTest < ActiveSupport::TestCase
   include FailureRaisingBehavior
 


### PR DESCRIPTION
## What

Adds `ActiveRecord::ConnectionFailed` to `Failsafe::TRANSIENT_ACTIVE_RECORD_ERRORS` so that a terminated cache database connection degrades to a cache miss instead of propagating to the caller.

Fixes #307.

## Why

`ActiveRecord::ConnectionFailed` (added in Rails 7.1) is raised when a connection is terminated mid-query. Critically, it is a subclass of `ActiveRecord::StatementInvalid`, **not** of `ActiveRecord::ConnectionNotEstablished` — so even though the failsafe already rescues connection-related errors, this one slipped straight past the rescue list and surfaced to application code. Adding it alongside the existing transient connection errors restores the intended "cache is best-effort, never fatal" behavior.

## How it's tested

A new `SolidCacheConnectionFailedFailsafeTest` reuses the shared `FailureSafetyBehavior` and mirrors the existing timeout test (the pattern moved to in #285), emulating a terminated connection by stubbing the adapter to raise `ActiveRecord::ConnectionFailed`. It guards the regression: cache operations drop to a miss rather than raising.

The test helpers were also tidied up — `emulating_timeouts` and `emulating_connection_failures` now delegate to a shared `emulating_errors(error_class)` helper to avoid the near-verbatim duplication.

All test configurations pass (`TARGET_DB=sqlite bundle exec rake test`): 400 runs, 0 failures, 0 errors across all 8 config matrices. RuboCop is clean.

## Notes

No CHANGELOG entry — the repo has never maintained a CHANGELOG file, and recent bug-fix PRs (e.g. #286, #287) add none.